### PR TITLE
chore: configure static build and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Triggers the workflow automatically on pushes to the main branch
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Angular Project
+        # The --base-href flag is CRITICAL. It tells Angular to look for assets
+        # in the repository subdirectory, not the root domain.
+        run: npm run build -- --base-href /clinical-randomization-generator/
+
+      - name: Fix Angular Routing (Create 404.html)
+        # GitHub Pages doesn't understand SPA routing. This copies the index file
+        # so any direct URL hits are routed back through Angular's router.
+        run: cp dist/app/browser/index.html dist/app/browser/404.html
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist/app/browser'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/angular.json
+++ b/angular.json
@@ -29,12 +29,7 @@
             ],
             "styles": [
               "src/styles.css"
-            ],
-            "server": "src/main.server.ts",
-            "outputMode": "server",
-            "ssr": {
-              "entry": "src/server.ts"
-            }
+            ]
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
- Removed SSR configurations from `angular.json` to build client-side static files suitable for GitHub Pages.
- Created `.github/workflows/deploy.yml` with the required configuration to deploy the site to GitHub Pages on merges to the main branch.

---
*PR created automatically by Jules for task [12935374537299477545](https://jules.google.com/task/12935374537299477545) started by @fderuiter*