### PR TITLE
ci: update node version to 22.x in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install Dependencies


### PR DESCRIPTION
Update Node.js version in deploy workflow for semantic-release compatibility.

---
*PR created automatically by Jules for task [8292656636369650414](https://jules.google.com/task/8292656636369650414) started by @fderuiter*