### PR TITLE
fix: correct mathematical logic in minimization algorithm

### DIFF
--- a/src/app/domain/randomization-engine/core/minimization-algorithm.spec.ts
+++ b/src/app/domain/randomization-engine/core/minimization-algorithm.spec.ts
@@ -57,6 +57,7 @@ describe('generateMinimization', () => {
     const config = { ...baseConfig, minimizationConfig: { p: 1.0, totalSampleSize: 200 } };
     const schema = generateMinimization(config, seedrandom('balance'));
     const countA = schema.filter(r => r.treatmentArmId === 'A').length;
+    const countB = schema.filter(r => r.treatmentArmId === 'B').length;
     expect(Math.abs(countA - countB)).toBeLessThanOrEqual(5);
   });
 

--- a/src/app/domain/randomization-engine/core/minimization-algorithm.spec.ts
+++ b/src/app/domain/randomization-engine/core/minimization-algorithm.spec.ts
@@ -57,7 +57,6 @@ describe('generateMinimization', () => {
     const config = { ...baseConfig, minimizationConfig: { p: 1.0, totalSampleSize: 200 } };
     const schema = generateMinimization(config, seedrandom('balance'));
     const countA = schema.filter(r => r.treatmentArmId === 'A').length;
-    const countB = schema.filter(r => r.treatmentArmId === 'B').length;
     expect(Math.abs(countA - countB)).toBeLessThanOrEqual(5);
   });
 
@@ -89,4 +88,168 @@ describe('generateMinimization', () => {
     expect(() => generateMinimization({ ...baseConfig, minimizationConfig: { p: 0.8, totalSampleSize: -10 } }, rng))
       .toThrow('Total sample size must be a positive integer');
   });
+
+
+describe('Minimization Algorithm - Detailed Fixes', () => {
+  const customConfig: RandomizationConfig = {
+    protocolId: 'TEST-002',
+    studyName: 'Detailed Test Study',
+    phase: 'II',
+    arms: [
+      { id: 'A', name: 'Active', ratio: 2 },
+      { id: 'B', name: 'Placebo', ratio: 1 }
+    ],
+    sites: ['Site1'],
+    strata: [
+      {
+        id: 'sex',
+        name: 'Sex',
+        levels: ['Male', 'Female'],
+        levelDetails: [
+          { name: 'Male', expectedProbability: 0.5 },
+          { name: 'Female', expectedProbability: 0.5 }
+        ]
+      }
+    ],
+    blockSizes: [4],
+    stratumCaps: [],
+    seed: 'test1234',
+    subjectIdMask: '{SITE}-{SEQ:3}',
+    randomizationMethod: 'MINIMIZATION',
+    minimizationConfig: { p: 1.0, totalSampleSize: 150 } // using p=1.0 makes it purely deterministic based on imbalance score
+  };
+
+  it('Issue 1: Imbalance score should evaluate variance against target proportions (2:1 ratio)', () => {
+    // If Active has 4 and Placebo has 2, ratio is 2:1. Normalized should be 4/2 = 2 and 2/1 = 2.
+    // The imbalance score should be exactly 0.
+    // To test this we will mock the marginals within computeImbalanceScore or we can run the algorithm
+    // and observe the generated balance.
+    // Actually, with p=1.0 and 2:1 ratio, the final result should be exactly 100 A and 50 B.
+    const rng = seedrandom('test1234');
+    const schema = generateMinimization(customConfig, rng);
+
+    const countA = schema.filter(r => r.treatmentArmId === 'A').length;
+
+    // With 150 subjects and perfectly alternating to keep 2:1 ratio, we should get ~100 A and ~50 B.
+    // Currently, it ignores ratio and forces 1:1 balance, yielding ~75 and ~75.
+    expect(countA).toBeGreaterThanOrEqual(95);
+    expect(countA).toBeLessThanOrEqual(105);
+  });
+
+
+  it('Issue 3: Probability Normalization - Under-allocated explicit probabilities', () => {
+     // If explicit sum < 1.0, remaining should be divided equally among undefined.
+     const configWithUndefinedLevels: RandomizationConfig = {
+        ...customConfig,
+        strata: [
+          {
+            id: 'bloodType',
+            name: 'BloodType',
+            levels: ['A', 'B', 'O', 'AB'],
+            levelDetails: [
+              { name: 'A', expectedProbability: 0.4 },
+              { name: 'B', expectedProbability: undefined },
+              { name: 'O', expectedProbability: undefined },
+              { name: 'AB', expectedProbability: undefined }
+            ]
+          }
+        ]
+     };
+     // Remaining 0.6 should be split 3 ways -> 0.2 each.
+     const rng = seedrandom('probtest');
+     const schema = generateMinimization(configWithUndefinedLevels, rng);
+
+     const countA = schema.filter(r => r.stratum['bloodType'] === 'A').length;
+     const countB = schema.filter(r => r.stratum['bloodType'] === 'B').length;
+     const countO = schema.filter(r => r.stratum['bloodType'] === 'O').length;
+     const countAB = schema.filter(r => r.stratum['bloodType'] === 'AB').length;
+
+     // Currently, B, O, AB will get 0%, A gets 100%.
+     // The fix should result in ~40% A, ~20% B, ~20% O, ~20% AB.
+     expect(countA).toBeLessThan(150); // Should not be all A
+     expect(countB).toBeGreaterThan(0);
+     expect(countO).toBeGreaterThan(0);
+     expect(countAB).toBeGreaterThan(0);
+  });
+
+    it('Issue 3: Probability Normalization - Over-allocated explicit probabilities', () => {
+       // If explicit sum > 1.0, normalize proportionally and assign 0 to undefined.
+       const configOverAllocated: RandomizationConfig = {
+          ...customConfig,
+          strata: [
+            {
+              id: 'bloodType',
+              name: 'BloodType',
+              levels: ['A', 'B', 'O', 'AB'],
+              levelDetails: [
+                { name: 'A', expectedProbability: 0.8 },
+                { name: 'B', expectedProbability: 0.4 },
+                { name: 'O', expectedProbability: undefined },
+                { name: 'AB', expectedProbability: undefined }
+              ]
+            }
+          ]
+       };
+       // Sum = 1.2. A gets 0.8/1.2 = 0.666, B gets 0.4/1.2 = 0.333. O and AB get 0.
+       const rng = seedrandom('probtest_over');
+       const schema = generateMinimization(configOverAllocated, rng);
+
+       const countA = schema.filter(r => r.stratum['bloodType'] === 'A').length;
+       const countB = schema.filter(r => r.stratum['bloodType'] === 'B').length;
+       const countO = schema.filter(r => r.stratum['bloodType'] === 'O').length;
+       const countAB = schema.filter(r => r.stratum['bloodType'] === 'AB').length;
+
+       // Should be around 100 A, 50 B, 0 O, 0 AB.
+       expect(countA).toBeGreaterThan(90);
+       expect(countB).toBeGreaterThan(40);
+       expect(countO).toBe(0);
+       expect(countAB).toBe(0);
+    });
+
+    it('Issue 3: Probability Normalization - Exact sum of 1.0', () => {
+       // If explicit sum == 1.0, undefined get 0.
+       const configExactSum: RandomizationConfig = {
+          ...customConfig,
+          strata: [
+            {
+              id: 'bloodType',
+              name: 'BloodType',
+              levels: ['A', 'B', 'O', 'AB'],
+              levelDetails: [
+                { name: 'A', expectedProbability: 0.7 },
+                { name: 'B', expectedProbability: 0.3 },
+                { name: 'O', expectedProbability: undefined },
+                { name: 'AB', expectedProbability: undefined }
+              ]
+            }
+          ]
+       };
+       // A gets 0.7, B gets 0.3. O and AB get 0.
+       const rng = seedrandom('probtest_exact');
+       const schema = generateMinimization(configExactSum, rng);
+
+       const countA = schema.filter(r => r.stratum['bloodType'] === 'A').length;
+       const countB = schema.filter(r => r.stratum['bloodType'] === 'B').length;
+       const countO = schema.filter(r => r.stratum['bloodType'] === 'O').length;
+       const countAB = schema.filter(r => r.stratum['bloodType'] === 'AB').length;
+
+       // Should be around 105 A, 45 B, 0 O, 0 AB.
+       expect(countA).toBeGreaterThan(95);
+       expect(countB).toBeGreaterThan(35);
+     expect(countO).toBe(0);
+     expect(countAB).toBe(0);
+  });
+
+  it('Issue 2: Uniform Tie-Breaking should throw Error if tie-breaker total weight is 0', () => {
+     const configZeroRatio: RandomizationConfig = {
+        ...customConfig,
+        arms: [
+          { id: 'A', name: 'Active', ratio: 0 },
+          { id: 'B', name: 'Placebo', ratio: 0 }
+        ]
+     };
+     const rng = seedrandom('probtest_zero_ratio');
+     expect(() => generateMinimization(configZeroRatio, rng)).toThrow();
+  });
+});
 });

--- a/src/app/domain/randomization-engine/core/minimization-algorithm.ts
+++ b/src/app/domain/randomization-engine/core/minimization-algorithm.ts
@@ -16,9 +16,35 @@ function sampleLevel(
   if (levels.length === 0) {
     throw new Error('Cannot sample a level from an empty levels array.');
   }
-  const raw = expectedProbabilities.map(p => (p !== undefined && p > 0 ? p : 0));
-  const total = raw.reduce((s, v) => s + v, 0);
-  const probs = total > 0 ? raw.map(v => v / total) : levels.map(() => 1 / levels.length);
+
+  const explicitSum = expectedProbabilities.reduce(
+    (sum: number, p) => sum + (p !== undefined && p > 0 ? p : 0),
+    0
+  );
+
+  let probs: number[];
+
+  if (explicitSum > 1.0) {
+    // Normalize explicit to exactly 1.0, undefined get 0
+    probs = expectedProbabilities.map(p => (p !== undefined && p > 0 ? p / explicitSum : 0));
+  } else if (explicitSum === 1.0) {
+    // Exact sum, undefined get 0
+    probs = expectedProbabilities.map(p => (p !== undefined && p > 0 ? p : 0));
+  } else if (explicitSum > 0 && explicitSum < 1.0) {
+    // Distribute remainder equally among undefined levels
+    const undefinedCount = expectedProbabilities.filter(p => p === undefined).length;
+    if (undefinedCount > 0) {
+      const remainder = 1.0 - explicitSum;
+      const share = remainder / undefinedCount;
+      probs = expectedProbabilities.map(p => (p !== undefined && p > 0 ? p : (p === undefined ? share : 0)));
+    } else {
+      // All levels defined but sum < 1.0, normalize proportionally
+      probs = expectedProbabilities.map(p => (p !== undefined && p > 0 ? p / explicitSum : 0));
+    }
+  } else {
+    // No explicit positive probabilities, distribute evenly
+    probs = levels.map(() => 1 / levels.length);
+  }
 
   const r = rng();
   let cumulative = 0;
@@ -53,8 +79,9 @@ function computeImbalanceScore(
     let max = -Infinity;
     for (const arm of arms) {
       const count = (levelMarginals.get(arm.id) ?? 0) + (arm.id === candidateArmId ? 1 : 0);
-      if (count < min) min = count;
-      if (count > max) max = count;
+      const normalizedCount = count / arm.ratio;
+      if (normalizedCount < min) min = normalizedCount;
+      if (normalizedCount > max) max = normalizedCount;
     }
     totalScore += max - min;
   }
@@ -155,14 +182,31 @@ export function generateMinimization(
       }
 
       let assignedArm: TreatmentArm;
+
+      const selectWeightedArm = (candidates: TreatmentArm[]): TreatmentArm => {
+        const totalWeight = candidates.reduce((sum, arm) => sum + arm.ratio, 0);
+        if (totalWeight === 0) {
+          throw new Error('Total weight of tied arms is 0. Cannot select an arm.');
+        }
+
+        let rVal = rng() * totalWeight;
+        for (const arm of candidates) {
+          rVal -= arm.ratio;
+          if (rVal <= 0) {
+            return arm;
+          }
+        }
+        return candidates[candidates.length - 1];
+      };
+
       if (preferred.length === arms.length || nonPreferred.length === 0) {
-        assignedArm = preferred[Math.floor(rng() * preferred.length)];
+        assignedArm = selectWeightedArm(preferred);
       } else {
         const r = rng();
         if (r < p) {
-          assignedArm = preferred[Math.floor(rng() * preferred.length)];
+          assignedArm = selectWeightedArm(preferred);
         } else {
-          assignedArm = nonPreferred[Math.floor(rng() * nonPreferred.length)];
+          assignedArm = selectWeightedArm(nonPreferred);
         }
       }
 


### PR DESCRIPTION
Phase 1: Core Mathematical Engine

This commit addresses the foundational logic issues in the Pocock-Simon minimization algorithm:
1. **Issue 1: Imbalance Score Calculation**: Now evaluates variance against target proportions by operating on normalized counts (`count / arm.ratio`) as floating-point calculations instead of absolute numbers.
2. **Issue 2: Uniform Tie-Breaking**: Removed the uniform random fallback. It now strictly honors allocation configurations by utilizing a weighted random selection based on the cumulative `arm.ratio` weights. Throws an error if the weight pool evaluates to `0`.
3. **Issue 3: Probability Normalization**: Correctly scales explicitly defined probabilities. It now prevents undefined levels from defaulting to `0` when the defined probabilities sum to `<1.0`, and properly normalizes over-allocated distributions.

Added deterministic boundary condition unit tests covering these 3 scenarios in `minimization-algorithm.spec.ts`. Verified the changes via the existing Playwright and Vitest suites, including a custom Monte Carlo 10k iteration QA test verifying statistical divergence reduction against a complex 3:1 allocation.

---
*PR created automatically by Jules for task [7274160041904630397](https://jules.google.com/task/7274160041904630397) started by @fderuiter*