### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -55,6 +55,7 @@ import {APP_VERSION} from '../environments/version';
                 (click)="toggleThemeMenu($event)"
                 class="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-indigo-100 dark:text-slate-300 hover:bg-indigo-600 dark:hover:bg-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-white/30"
                 aria-label="Toggle colour theme"
+                title="Toggle colour theme"
                 [attr.aria-expanded]="themeMenuOpen()"
                 aria-haspopup="true"
               >
@@ -112,6 +113,7 @@ import {APP_VERSION} from '../environments/version';
               (click)="toggleThemeMenu($event)"
               class="flex items-center rounded-lg p-2 text-indigo-100 hover:bg-indigo-600 dark:hover:bg-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-white/30"
               aria-label="Toggle colour theme"
+              title="Toggle colour theme"
               [attr.aria-expanded]="themeMenuOpen()"
             >
               @if (theme.mode() === 'Light') {
@@ -139,6 +141,7 @@ import {APP_VERSION} from '../environments/version';
               [attr.aria-expanded]="mobileMenuOpen()"
               aria-controls="mobile-menu"
               aria-label="Toggle navigation menu"
+              title="Toggle navigation menu"
             >
               @if (!mobileMenuOpen()) {
                 <!-- Hamburger icon -->

--- a/src/app/core/components/update-banner.component.ts
+++ b/src/app/core/components/update-banner.component.ts
@@ -40,6 +40,7 @@ import { UpdateNotificationService } from '../services/update-notification.servi
           type="button"
           (click)="updateService.dismiss()"
           aria-label="Dismiss update notification"
+          title="Dismiss update notification"
           class="rounded-md p-1 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/src/app/domain/schema-management/components/schema-analytics-dashboard.component.ts
+++ b/src/app/domain/schema-management/components/schema-analytics-dashboard.component.ts
@@ -46,8 +46,9 @@ const BLINDED_COLOUR = '#94a3b8'; // slate-400
                 {{ viewState.activeFilter()!.value }}
                 <button
                   (click)="viewState.clearFilter()"
-                  class="ml-1 hover:text-indigo-600 dark:hover:text-indigo-200 leading-none"
+                  class="ml-1 hover:text-indigo-600 dark:hover:text-indigo-200 leading-none rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   aria-label="Remove filter"
+                  title="Remove filter"
                 >✕</button>
               </span>
               <button


### PR DESCRIPTION
💡 What: Added `title` attributes to several icon-only buttons across the application, and added standard focus styling to the filter-removal button on the schema analytics dashboard.
🎯 Why: To provide native hover tooltips for sighted users and ensure consistent keyboard focus visibility, enhancing overall accessibility and usability.
♿ Accessibility:
- Added `title` attribute matching `aria-label` for mobile and desktop theme toggles.
- Added `title` attribute matching `aria-label` for the mobile hamburger/close menu toggle.
- Added `title` attribute and focus outline classes to the "Remove filter" button in the schema analytics dashboard.
- Added `title` attribute matching `aria-label` to the dismiss update notification button.

---
*PR created automatically by Jules for task [14249399623967109102](https://jules.google.com/task/14249399623967109102) started by @fderuiter*