### PR TITLE
⚡ Bolt: Add ChangeDetectionStrategy.OnPush to domain components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-01 - Add ChangeDetectionStrategy.OnPush to missing Angular components
+**Learning:** This codebase relies heavily on Signals and RxJS, and the prompt instructions state: "To optimize frontend performance and prevent unnecessary re-renders in this Angular application (which relies heavily on Signals and RxJS), ensure components implement ChangeDetectionStrategy.OnPush." Several components in the `src/app/domain` folder were missing this.
+**Action:** Added `ChangeDetectionStrategy.OnPush` to `TagInputComponent`, `BlockPreviewComponent`, `ConfigFormComponent`, `ResultsGridComponent`, and `CodeGeneratorModalComponent`.

--- a/src/app/domain/schema-management/components/code-generator-modal.component.ts
+++ b/src/app/domain/schema-management/components/code-generator-modal.component.ts
@@ -1,10 +1,11 @@
-import { Component, signal, inject, OnInit } from '@angular/core';
+import { Component, signal, inject, OnInit , ChangeDetectionStrategy} from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { RandomizationEngineFacade } from '../../randomization-engine/randomization-engine.facade';
 import { CodeGeneratorService } from '../services/code-generator.service';
 import { CodeGenerationError } from '../errors/code-generation-errors';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-code-generator-modal',
   standalone: true,
   imports: [JsonPipe],

--- a/src/app/domain/schema-management/components/results-grid.component.ts
+++ b/src/app/domain/schema-management/components/results-grid.component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Component, computed, effect, signal, inject } from '@angular/core';
+import { Component, computed, effect, signal, inject , ChangeDetectionStrategy} from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { CdkMenuModule } from '@angular/cdk/menu';
 import { ScrollingModule } from '@angular/cdk/scrolling';
@@ -52,6 +52,7 @@ export type GridRow = BlockHeader | DataRow | BlockSummary;
 // ---------------------------------------------------------------------------
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-results-grid',
   standalone: true,
   imports: [CdkMenuModule, ScrollingModule, KeyValuePipe],

--- a/src/app/domain/study-builder/components/block-preview.component.ts
+++ b/src/app/domain/study-builder/components/block-preview.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, input , ChangeDetectionStrategy} from '@angular/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 /** One arm's data passed from the parent. */
@@ -111,6 +111,7 @@ export function buildPreviews(arms: ArmInput[], blockSizes: number[]): BlockPrev
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-block-preview',
   standalone: true,
   imports: [MatTooltipModule],

--- a/src/app/domain/study-builder/components/config-form.component.ts
+++ b/src/app/domain/study-builder/components/config-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, DestroyRef, ElementRef, HostListener, inject, OnInit, signal, Signal, ViewChild } from '@angular/core';
+import { Component, computed, DestroyRef, ElementRef, HostListener, inject, OnInit, signal, Signal, ViewChild , ChangeDetectionStrategy} from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { map, startWith } from 'rxjs/operators';
@@ -14,6 +14,7 @@ import { CapStrategy } from '../../core/models/randomization.model';
 import { ToastService } from '../../../core/services/toast.service';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-config-form',
   standalone: true,
   imports: [ReactiveFormsModule, CdkDropList, CdkDrag, CdkDragHandle, TagInputComponent, MatTooltipModule, BlockPreviewComponent],

--- a/src/app/domain/study-builder/components/tag-input.component.ts
+++ b/src/app/domain/study-builder/components/tag-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, ViewChild, ElementRef , ChangeDetectionStrategy} from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
@@ -10,6 +10,7 @@ import { Subscription } from 'rxjs';
  *   <app-tag-input [control]="form.get('sitesStr')" placeholder="Type a site ID…" />
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-tag-input',
   standalone: true,
   template: `


### PR DESCRIPTION
### 💡 What
Added `ChangeDetectionStrategy.OnPush` to five key Angular components within the `src/app/domain` module: `TagInputComponent`, `BlockPreviewComponent`, `ConfigFormComponent`, `ResultsGridComponent`, and `CodeGeneratorModalComponent`.

### 🎯 Why
The application is built on Angular 17+ heavily utilizing Signals and RxJS for reactive state management. By default, Angular components use `ChangeDetectionStrategy.Default`, causing them to be checked during every change detection cycle anywhere in the application. Applying `OnPush` informs Angular to only check these components when their Inputs change by reference, or when an event originates from within the component (or its children), drastically reducing unnecessary re-renders. 

### 📊 Impact
Reduces unnecessary UI re-renders significantly during form interactions and complex data updates. Because these are complex nested components (like the Data Grid and Forms), skipping their template evaluation yields measurable CPU/memory savings during fast user interactions.

### 🔬 Measurement
Run `pnpm start` and verify that the application still works correctly. Check that tests pass with `npx vitest run src/app` and that `pnpm lint` passes cleanly.

---
*PR created automatically by Jules for task [2061701171506434634](https://jules.google.com/task/2061701171506434634) started by @fderuiter*