### PR TITLE
⚡ Bolt: Enforce ChangeDetectionStrategy.OnPush across all Angular components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - ChangeDetectionStrategy.OnPush enforcement
+**Learning:** Found several Angular components lacking explicit `ChangeDetectionStrategy.OnPush` declaration.
+**Action:** Enforce `ChangeDetectionStrategy.OnPush` across all Angular components to improve rendering performance and minimize change detection cycles.

--- a/src/app/domain/schema-management/components/code-generator-modal.component.ts
+++ b/src/app/domain/schema-management/components/code-generator-modal.component.ts
@@ -1,12 +1,17 @@
-import { Component, signal, inject, OnInit } from '@angular/core';
+import { Component, signal, inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { RandomizationEngineFacade } from '../../randomization-engine/randomization-engine.facade';
 import { CodeGeneratorService } from '../services/code-generator.service';
 import { CodeGenerationError } from '../errors/code-generation-errors';
 
+/**
+ * ⚡ Bolt Performance Optimization:
+ * Added ChangeDetectionStrategy.OnPush to minimize unnecessary re-renders.
+ */
 @Component({
   selector: 'app-code-generator-modal',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [JsonPipe],
   templateUrl: './code-generator-modal.component.html'
 })

--- a/src/app/domain/schema-management/components/results-grid.component.ts
+++ b/src/app/domain/schema-management/components/results-grid.component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Component, computed, effect, signal, inject } from '@angular/core';
+import { Component, computed, effect, signal, inject, ChangeDetectionStrategy } from '@angular/core';
 import { KeyValuePipe } from '@angular/common';
 import { CdkMenuModule } from '@angular/cdk/menu';
 import { ScrollingModule } from '@angular/cdk/scrolling';
@@ -51,9 +51,14 @@ export type GridRow = BlockHeader | DataRow | BlockSummary;
 
 // ---------------------------------------------------------------------------
 
+/**
+ * ⚡ Bolt Performance Optimization:
+ * Added ChangeDetectionStrategy.OnPush to minimize unnecessary re-renders.
+ */
 @Component({
   selector: 'app-results-grid',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CdkMenuModule, ScrollingModule, KeyValuePipe],
   templateUrl: './results-grid.component.html',
   styles: [`

--- a/src/app/domain/study-builder/components/block-preview.component.ts
+++ b/src/app/domain/study-builder/components/block-preview.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 /** One arm's data passed from the parent. */
@@ -110,9 +110,14 @@ export function buildPreviews(arms: ArmInput[], blockSizes: number[]): BlockPrev
     });
 }
 
+/**
+ * ⚡ Bolt Performance Optimization:
+ * Added ChangeDetectionStrategy.OnPush to minimize unnecessary re-renders.
+ */
 @Component({
   selector: 'app-block-preview',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatTooltipModule],
   styles: [`
     .invalid-slot {

--- a/src/app/domain/study-builder/components/config-form.component.ts
+++ b/src/app/domain/study-builder/components/config-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, DestroyRef, ElementRef, HostListener, inject, OnInit, signal, Signal, ViewChild } from '@angular/core';
+import { Component, computed, DestroyRef, ElementRef, HostListener, inject, OnInit, signal, Signal, ViewChild, ChangeDetectionStrategy } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { map, startWith } from 'rxjs/operators';
@@ -13,9 +13,14 @@ import { computeProportionalCaps, validateProportionalPercentages } from '../../
 import { CapStrategy } from '../../core/models/randomization.model';
 import { ToastService } from '../../../core/services/toast.service';
 
+/**
+ * ⚡ Bolt Performance Optimization:
+ * Added ChangeDetectionStrategy.OnPush to minimize unnecessary re-renders.
+ */
 @Component({
   selector: 'app-config-form',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ReactiveFormsModule, CdkDropList, CdkDrag, CdkDragHandle, TagInputComponent, MatTooltipModule, BlockPreviewComponent],
   templateUrl: './config-form.component.html'
 })

--- a/src/app/domain/study-builder/components/tag-input.component.ts
+++ b/src/app/domain/study-builder/components/tag-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, ViewChild, ElementRef, ChangeDetectionStrategy, inject, ChangeDetectorRef } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
@@ -9,9 +9,15 @@ import { Subscription } from 'rxjs';
  * Usage:
  *   <app-tag-input [control]="form.get('sitesStr')" placeholder="Type a site ID…" />
  */
+/**
+ * ⚡ Bolt Performance Optimization:
+ * Added ChangeDetectionStrategy.OnPush to minimize unnecessary re-renders.
+ * View updates are now isolated to true input changes or explicit ChangeDetectorRef marks.
+ */
 @Component({
   selector: 'app-tag-input',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
       class="flex flex-wrap gap-1.5 items-center min-h-[44px] border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 bg-white dark:bg-slate-700 focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500 cursor-text transition-colors"
@@ -57,12 +63,18 @@ export class TagInputComponent implements OnInit, OnDestroy {
 
   private sub: Subscription | null = null;
 
+  // ChangeDetectorRef injected to support OnPush when external form updates occur.
+  private readonly cdr = inject(ChangeDetectorRef);
+
   ngOnInit(): void {
     this.tags = this.parseValue(this.control.value);
     this.sub = this.control.valueChanges.subscribe(v => {
       // Only sync inward if the change came from outside (e.g. loadPreset)
       if (v !== this.toStr()) {
         this.tags = this.parseValue(v);
+        // Explicitly mark for check because this component uses OnPush
+        // and form control value changes are asynchronous/external.
+        this.cdr.markForCheck();
       }
     });
   }


### PR DESCRIPTION
💡 What: Applied `ChangeDetectionStrategy.OnPush` to all components missing it (`tag-input`, `block-preview`, `config-form`, `results-grid`, `code-generator-modal`). Explicit explanatory comments were added to document the optimization, and `ChangeDetectorRef` was properly wired into asynchronous subscriptions in `tag-input` to prevent rendering regressions.
🎯 Why: In high-frequency, complex interactive views like the study builder, default change detection can cause significant frame drops by checking the entire component tree on every event. `OnPush` isolates updates strictly to components with altered Inputs or explicit `markForCheck()` calls.
📊 Impact: Considerably reduces main-thread blocking by limiting change detection cycles strictly to components with active changes. Especially beneficial for the computationally heavy `results-grid` and deep forms like `config-form`.
🔬 Measurement: Verify by executing the unit test suite (`npx vitest run src/app`) and using Angular DevTools to profile change detection cycles when rendering complex grids or interacting with form inputs.

---
*PR created automatically by Jules for task [16992638459101786519](https://jules.google.com/task/16992638459101786519) started by @fderuiter*