### PR TITLE
⚡ Bolt: Precalculate invariant keys in randomization algorithms

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-04 - Precomputing invariant keys for algorithms
+**Learning:** In the randomization algorithms (`randomization-algorithm.ts` and `minimization-algorithm.ts`), the performance was degraded by recalculating the same string keys (`.map().join('|')`) dynamically per element within inner looping or filtering logic (`activePool.filter()`). Precomputing string keys onto objects can significantly reduce object iteration overhead.
+**Action:** When filtering objects inside algorithmic hot-loops, check if filtering relies on keys that can be computed statically and add `_key` or related properties to the objects once, then access the pre-calculated property in the loop to vastly reduce redundant string manipulation and object iteration overhead.

--- a/src/app/domain/randomization-engine/core/minimization-algorithm.ts
+++ b/src/app/domain/randomization-engine/core/minimization-algorithm.ts
@@ -158,6 +158,7 @@ export function generateMinimization(
     // Filter activePool immediately for any combinations that have a cap of 0
     activePool = activePool.filter(combo => {
       const key = strata.map(s => combo[s.id] || '').join('|');
+      combo['_key'] = key;
       const cap = capsDict[key];
       return cap === undefined || cap > 0;
     });
@@ -205,9 +206,9 @@ export function generateMinimization(
       }
     } else {
       activePool = activePool.filter(combo => {
-        const key = strata.map(f => combo[f.id] || '').join('|');
-        const cap = capsDict[key];
-        const count = intersectionCounts[key] ?? 0;
+        const key = combo['_key'];
+        const cap = capsDict[key!];
+        const count = intersectionCounts[key!] ?? 0;
         return cap === undefined || count < cap;
       });
 

--- a/src/app/domain/randomization-engine/core/randomization-algorithm.ts
+++ b/src/app/domain/randomization-engine/core/randomization-algorithm.ts
@@ -154,9 +154,9 @@ function generateStandard(
   for (const site of resolvedConfig.sites) {
     let siteSubjectCount = 0;
     for (const stratum of strataCombinations) {
-      const comboKey = resolvedConfig.strata.map(s => stratum[s.id] || '').join('|');
+      const comboKey = stratum['_key'];
       const maxSubjectsPerStratum = capsDict[comboKey] || 0;
-      const stratumCode = computeStratumCode(resolvedConfig.strata, stratum);
+      const stratumCode = stratum['_stratumCode'];
 
       let stratumSubjectCount = 0;
       let blockNumber = 1;
@@ -179,7 +179,10 @@ function generateStandard(
             usedSubjectIds
           );
 
-          schema.push({ subjectId, site, stratum, stratumCode, blockNumber, blockSize, treatmentArm: arm.name, treatmentArmId: arm.id });
+          const cleanStratum = { ...stratum };
+          delete cleanStratum['_key'];
+          delete cleanStratum['_stratumCode'];
+          schema.push({ subjectId, site, stratum: cleanStratum, stratumCode, blockNumber, blockSize, treatmentArm: arm.name, treatmentArmId: arm.id });
 
           if (stratumSubjectCount >= maxSubjectsPerStratum) break;
         }
@@ -274,7 +277,7 @@ function generateMarginalOnly(
       const stratum = activePool[poolIdx];
 
       // Resolve block rule and pick a block size using the hierarchical strategy.
-      const stratumCode = computeStratumCode(resolvedConfig.strata, stratum);
+      const stratumCode = stratum['_stratumCode'];
       const rule = resolveBlockRule(resolvedConfig, site, stratumCode);
       if (!siteBlockStates.has(stratumCode)) {
         siteBlockStates.set(stratumCode, newBlockState());
@@ -308,8 +311,11 @@ function generateMarginalOnly(
           usedSubjectIds
         );
 
+        const cleanStratum = { ...stratum };
+        delete cleanStratum['_key'];
+        delete cleanStratum['_stratumCode'];
         schema.push({
-          subjectId, site, stratum, stratumCode,
+          subjectId, site, stratum: cleanStratum, stratumCode,
           blockNumber,
           blockSize,
           treatmentArm: arm.name,
@@ -370,6 +376,12 @@ export function generateRandomizationSchema(config: RandomizationConfig): Random
     }
     strataCombinations = newCombinations;
   }
+
+  // Precalculate invariant keys for performance
+  strataCombinations.forEach(combo => {
+    combo['_key'] = resolvedConfig.strata.map(s => combo[s.id] || '').join('|');
+    combo['_stratumCode'] = computeStratumCode(resolvedConfig.strata, combo);
+  });
 
   // Calculate total ratio sum
   const totalRatio = resolvedConfig.arms.reduce((sum, arm) => sum + arm.ratio, 0);


### PR DESCRIPTION
💡 **What**: Precalculates invariant string keys (`_key` and `_stratumCode`) onto combination objects directly before they enter performance-critical algorithmic loops in both the `minimization-algorithm.ts` and `randomization-algorithm.ts` engines. It strips these hidden properties before final schema output.

🎯 **Why**: In the old implementation, the core logic recalculated a complex key via `strata.map(s => combo[s.id] || '').join('|')` on *every element* on *every iteration* inside `.filter()` operations or loops. This created a massive CPU overhead (redundant string generation, object iteration, garbage collection) as the total combinations scaled. 

📊 **Impact**: Vastly reduces redundant string manipulation, array iteration, and garbage collection pressure in algorithmic hot-loops, keeping scale-out iterations fast and memory allocation strictly bounded.

🔬 **Measurement**: Verified by ensuring the `pnpm test` baseline (`randomization-algorithm-parity.spec.ts`) retains absolute 1:1 mathematical parity with the old behavior without introducing new test regressions.

---
*PR created automatically by Jules for task [1183047473357827340](https://jules.google.com/task/1183047473357827340) started by @fderuiter*