### PR TITLE
🎨 Palette: Use accessible button role switch for blinding toggle

### DIFF
--- a/src/app/domain/schema-management/components/results-grid.component.html
+++ b/src/app/domain/schema-management/components/results-grid.component.html
@@ -70,16 +70,15 @@
 
           <div class="h-6 w-px bg-gray-300 dark:bg-slate-600 mx-1"></div>
 
-          <label class="flex items-center cursor-pointer">
+          <button type="button" role="switch" [attr.aria-checked]="isUnblinded()" (click)="toggleBlinding()" class="flex items-center cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 rounded px-1 -ml-1">
             <div class="relative">
-              <input type="checkbox" class="sr-only" [checked]="isUnblinded()" (change)="toggleBlinding()">
               <div class="block bg-gray-200 dark:bg-slate-600 w-10 h-6 rounded-full transition-colors" [class.bg-indigo-500]="isUnblinded()" [class.dark:bg-indigo-500]="isUnblinded()"></div>
               <div class="dot absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition-transform" [class.translate-x-4]="isUnblinded()"></div>
             </div>
             <span class="ml-3 text-sm font-medium text-gray-700 dark:text-slate-300">
               {{ isUnblinded() ? 'Unblinded' : 'Blinded' }}
             </span>
-          </label>
+          </button>
           
           <div class="h-6 w-px bg-gray-300 dark:bg-slate-600 mx-1"></div>
           

--- a/tests_e2e/results-operations.spec.ts
+++ b/tests_e2e/results-operations.spec.ts
@@ -86,7 +86,7 @@ test.describe('Results Grid Operations', () => {
   });
 
   test('should reveal treatment arms after clicking the blinding toggle', async ({ page }) => {
-    const toggleLabel = page.locator('#results-section label').filter({ hasText: /Blinded|Unblinded/i });
+    const toggleLabel = page.locator('#results-section button[role="switch"]');
     await toggleLabel.click();
 
     const firstRow = page.locator('[data-testid="result-row"]').first();
@@ -96,7 +96,7 @@ test.describe('Results Grid Operations', () => {
   });
 
   test('should re-blind the schema when the toggle is clicked a second time', async ({ page }) => {
-    const toggleLabel = page.locator('#results-section label').filter({ hasText: /Blinded|Unblinded/i });
+    const toggleLabel = page.locator('#results-section button[role="switch"]');
     const firstRow = page.locator('[data-testid="result-row"]').first();
     const armCell = firstRow.locator('[data-testid="result-arm-cell"]');
 

--- a/tests_e2e/schema-generation.spec.ts
+++ b/tests_e2e/schema-generation.spec.ts
@@ -42,7 +42,7 @@ test.describe('Schema Generation Flow', () => {
     await expect(armCell).toContainText('*** BLINDED ***');
 
     // Click the "Unblinded" toggle
-    const unblindedToggleLabel = page.locator('label').filter({ hasText: 'Blinded' }).or(page.locator('label').filter({ hasText: 'Unblinded' }));
+    const unblindedToggleLabel = page.locator('button[role="switch"]');
     await unblindedToggleLabel.click();
 
     // Assert the text changes from "*** BLINDED ***"


### PR DESCRIPTION
💡 **What:** Replaced the hidden `<input type="checkbox">` and `<label>` wrapper for the "Unblinded / Blinded" toggle with a semantic `<button role="switch">`.
🎯 **Why:** Custom toggle switches implemented as hidden checkboxes often fail to communicate state accurately to screen readers and, crucially, do not receive native `focus-visible` styling when navigated via keyboard. This makes the interface less accessible and intuitive for keyboard-only users.
♿ **Accessibility:** The toggle is now a proper semantic `role="switch"` element with dynamically bound `[attr.aria-checked]`. It features a clear focus ring using Tailwind's `focus-visible` classes, ensuring keyboard users know exactly where their focus lies.

---
*PR created automatically by Jules for task [18429154684553619618](https://jules.google.com/task/18429154684553619618) started by @fderuiter*