### PR TITLE
⚡ Bolt: [performance improvement] Optimize O(N) array filtering in core algorithm loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Optimize O(N) array filtering in algorithm loops
+**Learning:** O(N) array filtering operations (`.filter()`) inside large simulation loops (like Monte Carlo aggregations for randomization schemas) cause significant performance degradation when called unconditionally per iteration, even if the state hasn't changed.
+**Action:** Introduce a boolean flag (e.g., `poolNeedsFilter`) to short-circuit filtering until state changes make it necessary. Initialize the flag to `true` to ensure the initial pool is correctly filtered against any historical assignments that may have already reached their caps.

--- a/src/app/domain/randomization-engine/core/minimization-algorithm.ts
+++ b/src/app/domain/randomization-engine/core/minimization-algorithm.ts
@@ -208,6 +208,8 @@ export function generateMinimization(
     siteMarginals.set(site, marginals);
   }
 
+  let poolNeedsFilter = true;
+
   // Generate subjects one by one up to totalSampleSize
   for (let s = 0; s < totalSampleSize; s++) {
     // Determine active pool dynamically. If MARGINAL_ONLY, filter based on marginal counts.
@@ -223,12 +225,15 @@ export function generateMinimization(
         break;
       }
     } else {
-      activePool = activePool.filter(combo => {
-        const key = combo._key || "";
-        const cap = capsDict[key];
-        const count = intersectionCounts[key] ?? 0;
-        return cap === undefined || count < cap;
-      });
+      if (poolNeedsFilter) {
+        activePool = activePool.filter(combo => {
+          const key = combo._key || "";
+          const cap = capsDict[key];
+          const count = intersectionCounts[key] ?? 0;
+          return cap === undefined || count < cap;
+        });
+        poolNeedsFilter = false;
+      }
 
       if (activePool.length === 0) {
         // No more valid combinations exist; exhaustion reached.
@@ -365,7 +370,12 @@ export function generateMinimization(
         if (j > 0) key += "|";
         key += subjectProfile[strata[j].id] || "";
       }
-      intersectionCounts[key] = (intersectionCounts[key] ?? 0) + 1;
+      const newCount = (intersectionCounts[key] ?? 0) + 1;
+      intersectionCounts[key] = newCount;
+      const cap = capsDict[key];
+      if (cap !== undefined && newCount >= cap) {
+        poolNeedsFilter = true;
+      }
     }
 
     siteSubjectCounts.set(site, siteSubjectCounts.get(site)! + 1);

--- a/src/app/domain/randomization-engine/core/randomization-algorithm.ts
+++ b/src/app/domain/randomization-engine/core/randomization-algorithm.ts
@@ -267,6 +267,7 @@ function generateMarginalOnly(
 
     // Active pool of valid stratum combinations (those that haven't hit any marginal cap).
     let activePool = [...strataCombinations];
+    let poolNeedsFilter = true;
 
     while (activePool.length > 0) {
       // Randomly select a combination from the active pool.
@@ -322,22 +323,30 @@ function generateMarginalOnly(
           if (levelValue) {
             const countMap = marginalCounts.get(factor.id);
             if (countMap) {
-              countMap.set(levelValue, (countMap.get(levelValue) ?? 0) + 1);
+              const newCount = (countMap.get(levelValue) ?? 0) + 1;
+              countMap.set(levelValue, newCount);
+              const cap = marginalCapMap.get(factor.id)?.get(levelValue);
+              if (cap !== undefined && newCount >= cap) {
+                poolNeedsFilter = true;
+              }
             }
           }
         }
       }
 
       // Remove combinations from the pool that would now breach a marginal cap.
-      activePool = activePool.filter(combo =>
-        resolvedConfig.strata.every(factor => {
-          const levelValue = combo[factor.id] || '';
-          if (!levelValue) return true;
-          const cap = marginalCapMap.get(factor.id)?.get(levelValue);
-          if (cap === undefined) return true; // uncapped
-          return (marginalCounts.get(factor.id)?.get(levelValue) ?? 0) < cap;
-        })
-      );
+      if (poolNeedsFilter) {
+        activePool = activePool.filter(combo =>
+          resolvedConfig.strata.every(factor => {
+            const levelValue = combo[factor.id] || '';
+            if (!levelValue) return true;
+            const cap = marginalCapMap.get(factor.id)?.get(levelValue);
+            if (cap === undefined) return true; // uncapped
+            return (marginalCounts.get(factor.id)?.get(levelValue) ?? 0) < cap;
+          })
+        );
+        poolNeedsFilter = false;
+      }
     }
   }
 }


### PR DESCRIPTION
**💡 What**:
Introduced a boolean flag (`poolNeedsFilter`) to short-circuit expensive O(N) array filtering operations (`.filter()`) inside large, hot algorithmic loops (`minimization-algorithm.ts` and `randomization-algorithm.ts`). The filter only executes when relevant combination capacities actually increment enough to breach a defined limit, rather than unconditionally on every loop iteration.

**🎯 Why**: 
Calling `.filter()` unconditionally per iteration in large Monte Carlo aggregations (which can generate thousands of combinations over thousands of passes) is a significant performance bottleneck. This fix addresses this redundant algorithmic degradation by ensuring the dataset is only processed when state has substantively changed. 

**📊 Impact**:
Drastically reduces unnecessary array traversals in hot simulation loops, vastly improving the speed and memory efficiency of the core clinical randomization generator, particularly for configurations with high subject caps and extensive strata combinations. 

**🔬 Measurement**:
Tests were run via `npx vitest run src/app` before and after to ensure zero logic regressions or parity drift. Simulation times for large configurations will demonstrate statistically significant speed increases. Code changes remain under 50 lines total. Key learnings logged in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [16804344759424513120](https://jules.google.com/task/16804344759424513120) started by @fderuiter*