### PR TITLE
🎨 Palette: Add UX tooltips and ARIA labels to result grid buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Add tooltips (titles) and ARIA labels to button groups
+**Learning:** Icon-only or partially icon-based action buttons in the results grid missed tooltip context (title) and distinct ARIA labels (e.g. Export buttons missing 'Export as Excel' semantics for screen readers).
+**Action:** When creating grouped UI actions or icon-driven data export buttons, always supply `title` for sighted users and `aria-label` for assistive technology to clarify intent.

--- a/src/app/domain/schema-management/components/results-grid.component.html
+++ b/src/app/domain/schema-management/components/results-grid.component.html
@@ -55,6 +55,7 @@
               role="radio"
               [attr.aria-checked]="viewMode() === 'flat'"
               (click)="viewMode.set('flat')"
+              title="View as Flat List"
               class="px-3 py-1.5 transition-colors"
               [class]="viewMode() === 'flat'
                 ? 'bg-indigo-500 text-white'
@@ -66,6 +67,7 @@
               role="radio"
               [attr.aria-checked]="viewMode() === 'grouped'"
               (click)="viewMode.set('grouped')"
+              title="Group by Block"
               class="px-3 py-1.5 transition-colors border-l border-border-strong"
               [class]="viewMode() === 'grouped'
                 ? 'bg-indigo-500 text-white'
@@ -88,7 +90,7 @@
           
           <div class="h-6 w-px bg-gray-300 dark:bg-slate-600 mx-1"></div>
           
-          <button (click)="exportCsv()" class="min-h-[44px] text-sm bg-white dark:bg-slate-700 border border-border-strong text-gray-700 dark:text-slate-300 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-600 font-medium transition-colors flex items-center gap-1">
+          <button (click)="exportCsv()" title="Export as CSV" aria-label="Export as CSV" class="min-h-[44px] text-sm bg-white dark:bg-slate-700 border border-border-strong text-gray-700 dark:text-slate-300 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-600 font-medium transition-colors flex items-center gap-1">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
@@ -98,13 +100,14 @@
             (click)="exportXlsx()"
             data-testid="export-xlsx-btn"
             title="Export as Excel (.xlsx) – preserves leading zeros and provides two-sheet audit workbook"
+            aria-label="Export as Excel"
             class="min-h-[44px] text-sm bg-white dark:bg-slate-700 border border-border-strong text-gray-700 dark:text-slate-300 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-600 font-medium transition-colors flex items-center gap-1">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>
             Excel
           </button>
-          <button (click)="exportPdf()" class="min-h-[44px] text-sm bg-white dark:bg-slate-700 border border-border-strong text-gray-700 dark:text-slate-300 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-600 font-medium transition-colors flex items-center gap-1">
+          <button (click)="exportPdf()" title="Export as PDF" aria-label="Export as PDF" class="min-h-[44px] text-sm bg-white dark:bg-slate-700 border border-border-strong text-gray-700 dark:text-slate-300 px-3 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-600 font-medium transition-colors flex items-center gap-1">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>


### PR DESCRIPTION
💡 **What:** Added missing `title` and `aria-label` attributes to the export action buttons (CSV, Excel, PDF) and the View Mode toggles (Flat List, Group by Block) on the Results Grid.
🎯 **Why:** To ensure clear communication of intent. Sighted users now get native browser hover tooltips, and screen readers get accurate context instead of just reading "CSV".
📸 **Before/After:** Not a visual change beyond hover tooltips appearing.
♿ **Accessibility:** Added specific `aria-label`s to data export buttons (e.g. `aria-label="Export as CSV"`) and `title`s to toggle button groups for improved usability.

---
*PR created automatically by Jules for task [16725573255715586460](https://jules.google.com/task/16725573255715586460) started by @fderuiter*