### PR TITLE
fix(study-builder): allow fractional expected-distribution inputs with step=any

### DIFF
--- a/src/app/domain/study-builder/components/config-form.component.html
+++ b/src/app/domain/study-builder/components/config-form.component.html
@@ -172,7 +172,7 @@
                     @for (level of getStrataLevels(stratumIndex); track level) {
                       <div class="flex items-center gap-2 mb-1">
                         <label [for]="'levelDist' + getStrataId(stratumIndex) + '_' + level" class="text-xs flex-1">{{ level }}</label>
-                        <input #probInput [id]="'levelDist' + getStrataId(stratumIndex) + '_' + level" type="number" min="0" max="100"
+                        <input #probInput [id]="'levelDist' + getStrataId(stratumIndex) + '_' + level" type="number" min="0" max="100" step="any"
                                [value]="getMinimizationProbability(getStrataId(stratumIndex), level)"
                                (input)="setMinimizationProbability(getStrataId(stratumIndex), level, +probInput.value)"
                                class="w-20 rounded-lg border px-2 py-1 text-sm">

--- a/tests_e2e/form-validation.spec.ts
+++ b/tests_e2e/form-validation.spec.ts
@@ -144,4 +144,41 @@ test.describe('Form Validation and Configuration', () => {
     const capRows = page.locator('[formArrayName="stratumCaps"] > div');
     await expect(capRows).toHaveCount(2, { timeout: 5000 });
   });
+
+  // ---------------------------------------------------------------------------
+  // Minimization distribution fractional inputs
+  // ---------------------------------------------------------------------------
+  test('should allow fractional values in minimization distribution inputs', async ({ page }) => {
+    await loadPreset(page, 'Simple');
+
+    // Setup for minimization
+    await goToStep(page, 2);
+    await page.getByRole('radio', { name: 'Minimization' }).click();
+
+    await page.locator("button:has-text('Next'):visible").first().click(); // Go to step 3
+
+    await page.getByRole('button', { name: /\+ Add Factor/i }).click();
+    const strataRows = page.locator('[formArrayName="strata"] > div');
+    await expect(strataRows).toHaveCount(1, { timeout: 5000 });
+
+    const firstStratumRow = strataRows.first();
+    const levelsInput = firstStratumRow.locator('app-tag-input input').first();
+    await levelsInput.waitFor({ state: 'visible', timeout: 10000 });
+    await levelsInput.fill('Level1');
+    await levelsInput.press('Enter');
+    await levelsInput.fill('Level2');
+    await levelsInput.press('Enter');
+    await levelsInput.press('Tab');
+
+    // Enter 0.33 into the first minimization distribution input
+    const minInput = firstStratumRow.locator('input[type="number"]').first();
+    await minInput.fill('0.33');
+
+    // Evaluate if the input is valid at the browser level
+    const isValid = await minInput.evaluate((el: HTMLInputElement) => el.checkValidity());
+    expect(isValid).toBe(true);
+
+    // We expect the value to persist and not be cleared/flagged by step validation
+    await expect(minInput).toHaveValue('0.33');
+  });
 });

--- a/tests_e2e/generator-helpers.ts
+++ b/tests_e2e/generator-helpers.ts
@@ -19,7 +19,7 @@ export async function loadPreset(page: Page, preset: 'Simple' | 'Standard' | 'Co
  */
 export async function goToStep(page: Page, step: number): Promise<void> {
   for (let i = 0; i < Math.max(0, step - FIRST_WIZARD_STEP); i++) {
-    await page.getByRole('button', { name: /^Next$/i }).click();
+    await page.locator("button:has-text('Next'):visible").first().click();
   }
 }
 


### PR DESCRIPTION
Fixes #281 by setting `step="any"` on the minimization distribution probability `<input type="number">`. Also adds a Playwright E2E test to verify fractional values can be inputted without native browser validation failing.

---
*PR created automatically by Jules for task [10754768887849312428](https://jules.google.com/task/10754768887849312428) started by @fderuiter*