### PR TITLE
feat(study-builder): add inline validation for minimization probabilities

### DIFF
--- a/src/app/domain/study-builder/components/config-form.component.html
+++ b/src/app/domain/study-builder/components/config-form.component.html
@@ -175,13 +175,18 @@
                         <input #probInput [id]="'levelDist' + getStrataId(stratumIndex) + '_' + level" type="number" min="0" max="100"
                                [value]="getMinimizationProbability(getStrataId(stratumIndex), level)"
                                (input)="setMinimizationProbability(getStrataId(stratumIndex), level, +probInput.value)"
-                               class="w-20 rounded-lg border px-2 py-1 text-sm">
+                               (blur)="markMinimizationProbabilityTouched(getStrataId(stratumIndex))"
+                               class="w-20 rounded-lg border px-2 py-1 text-sm"
+                               [class.border-red-500]="isMinimizationProbabilityInvalid(getStrataId(stratumIndex)) && isMinimizationProbabilityTouched(getStrataId(stratumIndex))">
                         <span class="text-xs">%</span>
                       </div>
                     }
                     <p class="text-xs" [class.text-red-600]="isMinimizationProbabilityInvalid(getStrataId(stratumIndex))">
                       Total: {{ getMinimizationProbabilityTotal(getStrataId(stratumIndex), getStrataLevels(stratumIndex)) }}% (must sum to 100%)
                     </p>
+                    @if (isMinimizationProbabilityInvalid(getStrataId(stratumIndex)) && isMinimizationProbabilityTouched(getStrataId(stratumIndex))) {
+                      <p class="text-xs text-red-600 mt-1">Probabilities must sum to exactly 100%.</p>
+                    }
                   </div>
                 }
               </div>

--- a/src/app/domain/study-builder/components/config-form.component.spec.ts
+++ b/src/app/domain/study-builder/components/config-form.component.spec.ts
@@ -318,6 +318,32 @@ describe('ConfigFormComponent (domain)', () => {
       expect(component.isStrataStepNextDisabled).toBe(false);
     });
 
+    it('should display inline validation error only when touched and invalid', () => {
+      component.form.get('designGroup.randomizationMethod')?.setValue('MINIMIZATION');
+
+      // Initially untouched
+      expect(component.isMinimizationProbabilityTouched('age')).toBe(false);
+
+      // Set to invalid
+      component.setMinimizationProbability('age', '<65', 60);
+      component.setMinimizationProbability('age', '>=65', 30);
+      component.form.updateValueAndValidity();
+      expect(component.isMinimizationProbabilityInvalid('age')).toBe(true);
+
+      // Still untouched
+      expect(component.isMinimizationProbabilityTouched('age')).toBe(false);
+
+      // Trigger touched
+      component.markMinimizationProbabilityTouched('age');
+      expect(component.isMinimizationProbabilityTouched('age')).toBe(true);
+
+      // Fix probabilities (valid)
+      component.setMinimizationProbability('age', '<65', 50);
+      component.setMinimizationProbability('age', '>=65', 50);
+      component.form.updateValueAndValidity();
+      expect(component.isMinimizationProbabilityInvalid('age')).toBe(false);
+    });
+
     it('should immediately invalidate the form when strata sync makes minimization totals stale', () => {
       component.form.get('designGroup.randomizationMethod')?.setValue('MINIMIZATION');
       component.setMinimizationProbability('age', '<65', 50);

--- a/src/app/domain/study-builder/components/config-form.component.ts
+++ b/src/app/domain/study-builder/components/config-form.component.ts
@@ -64,6 +64,11 @@ export class ConfigFormComponent implements OnInit {
    */
   readonly minimizationProbabilities = signal<Record<string, Record<string, number>>>({});
 
+  /**
+   * Tracks whether the minimization probability inputs for a given factor have been touched (blurred).
+   */
+  readonly minimizationTouched = signal<Record<string, boolean>>({});
+
   /** Whether the computed proportional matrix has been generated and is ready to display. */
   readonly matrixComputed = signal(false);
 
@@ -777,6 +782,14 @@ export class ConfigFormComponent implements OnInit {
   getMinimizationProbabilityTotal(factorId: string, levels: string[]): number {
     const probs = this.minimizationProbabilities();
     return levels.reduce((sum, l) => sum + (probs[factorId]?.[l] ?? 0), 0);
+  }
+
+  isMinimizationProbabilityTouched(factorId: string): boolean {
+    return !!this.minimizationTouched()[factorId];
+  }
+
+  markMinimizationProbabilityTouched(factorId: string): void {
+    this.minimizationTouched.update(prev => ({ ...prev, [factorId]: true }));
   }
 
   isMinimizationProbabilityInvalid(factorId: string): boolean {


### PR DESCRIPTION
Adds inline validation feedback for minimization probability inputs in the config form. By tracking a `touched` state on blur for each factor, it ensures the red error message ("Probabilities must sum to exactly 100%.") and red input borders only appear after user interaction, addressing the issue where users received no actionable feedback when values did not sum to 1. Included unit tests to assert the visibility and state transitions.

---
*PR created automatically by Jules for task [7878213827407253489](https://jules.google.com/task/7878213827407253489) started by @fderuiter*