### PR TITLE
ops: create GitHub issue forms and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Create a report to help us improve
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What type of issue is this?
+      options:
+        - Bug
+        - Feature
+        - Test Gap
+        - Refactor / Tech Debt
+        - Release Hardening
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area does this issue affect?
+      options:
+        - UI/UX
+        - Backend/API
+        - Documentation
+        - Core Algorithm
+        - Build/Infrastructure
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior / Gap
+      description: What actually happened or what is the gap?
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What needs to be done for this issue to be considered resolved?
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test Plan
+      description: How will this change be tested?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,61 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What type of issue is this?
+      options:
+        - Feature
+        - Bug
+        - Test Gap
+        - Refactor / Tech Debt
+        - Release Hardening
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area does this issue affect?
+      options:
+        - UI/UX
+        - Backend/API
+        - Documentation
+        - Core Algorithm
+        - Build/Infrastructure
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What is the expected behavior or feature?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior / Gap
+      description: What is the current behavior or gap?
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What needs to be done for this issue to be considered resolved?
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test Plan
+      description: How will this change be tested?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,61 @@
+name: Refactor / Tech Debt
+description: Suggest code improvements and cleanup
+title: "[Refactor]: "
+labels: ["refactor"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What type of issue is this?
+      options:
+        - Refactor / Tech Debt
+        - Bug
+        - Feature
+        - Test Gap
+        - Release Hardening
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area does this issue affect?
+      options:
+        - UI/UX
+        - Backend/API
+        - Documentation
+        - Core Algorithm
+        - Build/Infrastructure
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should the code look/act like after the refactor?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior / Gap
+      description: What is the current state of the code or the technical debt?
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What needs to be done for this issue to be considered resolved?
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test Plan
+      description: How will this change be tested?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/release-hardening.yml
+++ b/.github/ISSUE_TEMPLATE/release-hardening.yml
@@ -1,0 +1,61 @@
+name: Release Hardening
+description: Report tasks needed for release readiness
+title: "[Release Hardening]: "
+labels: ["release-hardening"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What type of issue is this?
+      options:
+        - Release Hardening
+        - Bug
+        - Feature
+        - Test Gap
+        - Refactor / Tech Debt
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area does this issue affect?
+      options:
+        - UI/UX
+        - Backend/API
+        - Documentation
+        - Core Algorithm
+        - Build/Infrastructure
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What is the expected behavior for the release?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior / Gap
+      description: What is the current behavior or what remains to be hardened?
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What needs to be done for this issue to be considered resolved?
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test Plan
+      description: How will this change be tested?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/test-gap.yml
+++ b/.github/ISSUE_TEMPLATE/test-gap.yml
@@ -1,0 +1,61 @@
+name: Test Gap
+description: Report a missing test coverage
+title: "[Test Gap]: "
+labels: ["test-gap"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What type of issue is this?
+      options:
+        - Test Gap
+        - Bug
+        - Feature
+        - Refactor / Tech Debt
+        - Release Hardening
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area does this issue affect?
+      options:
+        - UI/UX
+        - Backend/API
+        - Documentation
+        - Core Algorithm
+        - Build/Infrastructure
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What is the expected behavior of the covered code?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior / Gap
+      description: What is the current test coverage gap?
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What needs to be done for this issue to be considered resolved?
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test Plan
+      description: How will the new tests be verified?
+    validations:
+      required: true


### PR DESCRIPTION
This commit adds five structured YAML issue templates (bug, feature, test-gap, refactor, release hardening) to `.github/ISSUE_TEMPLATE/`. Each template includes dropdowns for Type and Area, and textareas for Expected Behavior, Actual Behavior / Gap, Acceptance Criteria, and Test Plan. Validations ensure all fields are required, standardizing the issue reporting process and addressing issue #325.

---
*PR created automatically by Jules for task [4928994323454819505](https://jules.google.com/task/4928994323454819505) started by @fderuiter*