### PR TITLE
ops: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Linked Issue
+<!-- Please link the issue this PR resolves (e.g. `Fixes #123`) -->
+Fixes #
+
+## Change Type
+<!-- Please check the relevant option(s) -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Code health/refactor
+- [ ] Documentation
+- [ ] Security fix
+- [ ] Performance improvement
+- [ ] Other (please describe)
+
+## Risk Area
+<!-- Briefly describe any potential risks or areas that reviewers should pay close attention to. -->
+
+
+## Tests Added/Updated
+<!-- Detail the unit/E2E tests you've added or updated. Provide evidence such as test logs or command outputs. -->
+
+
+## Screenshots (For UI Changes)
+<!-- If this PR includes UI changes, please provide Before/After screenshots here. If not applicable, write "N/A". -->
+
+
+## Backward-Compat Notes (For Generator Changes)
+<!-- If this PR modifies the clinical randomization schema generators (R, Python, SAS, STATA), please detail backward compatibility implications. If not applicable, write "N/A". -->


### PR DESCRIPTION
Added `.github/PULL_REQUEST_TEMPLATE.md` to ensure future Pull Requests provide essential context, including linked issues, change type, risk areas, test evidence, screenshots, and backward compatibility notes.

---
*PR created automatically by Jules for task [16641607692000216765](https://jules.google.com/task/16641607692000216765) started by @fderuiter*