### PR TITLE
docs: document release checklist for regulated and statistical-confidence releases

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,12 @@
+# Release Checklist
+
+This checklist must be followed for all releases intended for regulated or statistical-confidence use.
+
+## Checklist
+
+- [ ] **CI Green:** Verify that all Continuous Integration (CI) checks have passed.
+- [ ] **Current SBOM:** Ensure the Software Bill of Materials (SBOM) is current and accurate.
+- [ ] **Cross-Environment Verification Passed:** Verify consistency across different environments (cross-env consistency).
+- [ ] **Audit Trail Validated:** Ensure audit trails are validated.
+- [ ] **Zero `Math.random` Usage:** Verify that there is no `Math.random` usage in the randomization engine. Cryptographically secure random number generation (CSPRNG) must be used.
+- [ ] **Generated Scripts Executed Successfully:** Ensure that all generated scripts (e.g., SAS, STATA, Python, R) have been executed successfully.


### PR DESCRIPTION
Adds a documented release checklist for releases intended for regulated or statistical-confidence use.

## What
Added `docs/RELEASE_CHECKLIST.md` containing the release checklist covering CI green, current SBOM, cross-env verification, audit trail validation, zero Math.random usage, and successful script execution.

## Why
No documented release checklist existed for regulated or statistical-confidence releases. This documentation ensures compliance and proper verification for such releases.

---
*PR created automatically by Jules for task [7169610332186757084](https://jules.google.com/task/7169610332186757084) started by @fderuiter*