### PR TITLE
🎨 Palette: Improve drag handle accessibility and visual affordance

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-20 - Drag Handle Affordance
+**Learning:** When implementing drag handles for sortable list items in the UI, relying on simple text characters (like `⋮⋮`) lacks sufficient visual cues for interactivity and accessibility. Users benefit from multiple layered affordances.
+**Action:** Use an SVG icon button with CSS classes for `cursor-grab`, `active:cursor-grabbing`, an explicit `aria-label`, a `title` attribute, and distinct `focus-visible` styling to ensure visual affordance and keyboard accessibility.

--- a/src/app/domain/study-builder/components/config-form.component.html
+++ b/src/app/domain/study-builder/components/config-form.component.html
@@ -150,7 +150,11 @@
             @for (stratum of strata.controls; track stratum; let stratumIndex = $index) {
               <div [formGroupName]="$index" cdkDrag class="rounded-xl border p-4 space-y-3">
                 <div class="flex items-start gap-2">
-                  <button type="button" cdkDragHandle aria-label="Drag to reorder factor" class="mt-2 text-xs text-gray-500">⋮⋮</button>
+                  <button type="button" cdkDragHandle aria-label="Drag to reorder factor" title="Drag to reorder" class="mt-2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded cursor-grab active:cursor-grabbing transition-colors">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M8 9h8M8 15h8" />
+                    </svg>
+                  </button>
                   <div class="flex-1 grid grid-cols-1 md:grid-cols-2 gap-3">
                     <div>
                       <label [for]="'factorName' + $index" class="block text-xs uppercase tracking-wide mb-1">Factor Name</label>

--- a/verification.py
+++ b/verification.py
@@ -1,0 +1,47 @@
+from playwright.sync_api import sync_playwright
+
+def run_cuj(page):
+    page.goto("http://localhost:4200")
+    page.wait_for_timeout(2000)
+
+    # Click the "Generator" link in the header
+    page.get_by_role("link", name="Generator").first.click()
+    page.wait_for_timeout(2000)
+
+    # We should be on step 1 of the wizard. Let's fill out basic metadata
+    page.get_by_label("Protocol ID").fill("TEST-123")
+    page.wait_for_timeout(500)
+    page.get_by_role("button", name="Next").click()
+    page.wait_for_timeout(1000)
+
+    # Step 2: Arms
+    page.get_by_role("button", name="Next").click()
+    page.wait_for_timeout(1000)
+
+    # Step 3: Strata - Check drag handle visual affordance
+    # Hover over the drag handle to trigger its styles
+    page.get_by_role("button", name="Drag to reorder factor").first.hover()
+    page.wait_for_timeout(500)
+
+    # Take screenshot of the hover state of the drag handle
+    page.screenshot(path="/home/jules/verification/screenshots/verification.png")
+    page.wait_for_timeout(1000)
+
+    # Focus the drag handle to show focus rings
+    page.get_by_role("button", name="Drag to reorder factor").first.focus()
+    page.wait_for_timeout(500)
+    page.screenshot(path="/home/jules/verification/screenshots/verification_focus.png")
+    page.wait_for_timeout(1000)
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            record_video_dir="/home/jules/verification/videos"
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+        finally:
+            context.close()
+            browser.close()


### PR DESCRIPTION
🎨 Palette: Improve drag handle accessibility and visual affordance

### 💡 What
Upgraded the text-based drag handle (`⋮⋮`) in the Stratification Factors list of the study-builder form to use an SVG icon. I added standard UX interaction classes (`cursor-grab`, `active:cursor-grabbing`) along with a `title` tooltip.

### 🎯 Why
Relying on simple text characters lacks sufficient visual cues for interactivity. Users benefit from multiple layered affordances to understand that an item can be reordered.

### 📸 Before/After
See attached videos and screenshots for the hover and focus states of the updated drag handle.

### ♿ Accessibility
Added `focus-visible:ring-2 focus-visible:ring-indigo-500` to ensure keyboard users receive clear focus feedback when tabbing to the drag handle, while maintaining an explicit `aria-label`. Added an entry to `.Jules/palette.md` to note this critical learning.

---
*PR created automatically by Jules for task [6964911502297798168](https://jules.google.com/task/6964911502297798168) started by @fderuiter*