### PR TITLE
🎨 Palette: Add ARIA attributes to Generate Code dropdown

### DIFF
--- a/src/app/domain/study-builder/components/config-form.component.html
+++ b/src/app/domain/study-builder/components/config-form.component.html
@@ -445,7 +445,7 @@
             Run Statistical QA
           </button>
           <div class="relative inline-block text-left" #dropdownContainer>
-            <button type="button" (click)="dropdownOpen = !dropdownOpen" [disabled]="!form.valid" class="bg-white border border-indigo-200 text-indigo-700 px-4 py-2 rounded-lg disabled:opacity-50 text-sm">
+            <button type="button" (click)="dropdownOpen = !dropdownOpen" [disabled]="!form.valid" aria-haspopup="menu" [attr.aria-expanded]="dropdownOpen" class="bg-white border border-indigo-200 text-indigo-700 px-4 py-2 rounded-lg disabled:opacity-50 text-sm">
               Generate Code
             </button>
             @if (dropdownOpen) {


### PR DESCRIPTION
**💡 What:**
Added `aria-haspopup="menu"` and dynamically bound `[attr.aria-expanded]="dropdownOpen"` to the "Generate Code" dropdown button in `config-form.component.html`.

**🎯 Why:**
This improves accessibility by explicitly marking the button as a menu trigger and communicating its current open/closed state to assistive technologies, making the multi-step schema generation flow more intuitive for screen reader users.

**📸 Before/After:**
- *Before:* The button was just a standard button triggering a menu, without semantic cues of its state.
- *After:* The button correctly announces itself as controlling a menu and conveys whether the dropdown is expanded or collapsed.

**♿ Accessibility:**
- Added `aria-haspopup="menu"` to indicate the presence of a contextual menu.
- Added `[attr.aria-expanded]="dropdownOpen"` to reflect the interactive state.

---
*PR created automatically by Jules for task [16306158724047625862](https://jules.google.com/task/16306158724047625862) started by @fderuiter*