### PR TITLE
🎨 Palette: Improve accessibility of tag remove button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-20 - Drag Handle Affordance
 **Learning:** When implementing drag handles for sortable list items in the UI, relying on simple text characters (like `⋮⋮`) lacks sufficient visual cues for interactivity and accessibility. Users benefit from multiple layered affordances.
 **Action:** Use an SVG icon button with CSS classes for `cursor-grab`, `active:cursor-grabbing`, an explicit `aria-label`, a `title` attribute, and distinct `focus-visible` styling to ensure visual affordance and keyboard accessibility.
+
+## 2026-05-21 - Remove Button Accessibility
+**Learning:** Icon-only remove buttons in tag/chip inputs need more than just an `aria-label`. They also require a `title` attribute so sighted mouse users can discover what the button does on hover, and proper focus styling for keyboard users.
+**Action:** Add `[attr.title]` and `focus-visible:ring-2 focus-visible:ring-indigo-500 rounded` to small removal buttons like the one in `TagInputComponent`.

--- a/src/app/domain/study-builder/components/tag-input.component.ts
+++ b/src/app/domain/study-builder/components/tag-input.component.ts
@@ -29,8 +29,9 @@ import { Subscription } from 'rxjs';
           <button
             type="button"
             (click)="removeTag(tag); $event.stopPropagation()" (keydown.enter)="removeTag(tag); $event.stopPropagation()" tabindex="0"
-            class="ml-0.5 text-indigo-500 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 focus:outline-none leading-none font-bold"
+            class="ml-0.5 text-indigo-500 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded leading-none font-bold"
             [attr.aria-label]="'Remove ' + tag"
+            [attr.title]="'Remove ' + tag"
           >×</button>
         </span>
       }


### PR DESCRIPTION
**💡 What**
Added a `title` attribute and `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-indigo-500 rounded`) to the small icon-only remove button in the `TagInputComponent`.

**🎯 Why**
Icon-only remove buttons need more than just an `aria-label`. They also require a `title` attribute so sighted mouse users can discover what the button does on hover, and proper focus styling for keyboard users. This improves both discoverability for mouse users and usability for keyboard navigators.

**♿ Accessibility**
- Added `[attr.title]` to provide a native hover tooltip.
- Added `focus-visible` ring styling to clearly indicate keyboard focus.

---
*PR created automatically by Jules for task [16597181088869533284](https://jules.google.com/task/16597181088869533284) started by @fderuiter*