### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix CSV Injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-25 - Prevent CSV Injection (Formula Injection)
+**Vulnerability:** Data exported to CSV can contain fields that start with executable characters (e.g., `=`, `+`, `-`, `@`, `\t`, `\r`), which spreadsheet programs like Excel or Google Sheets may automatically execute as formulas. This could lead to local command execution or data exfiltration.
+**Learning:** In the `ResultsGridComponent`, the `exportCsv` method generated CSV content simply by joining values with commas. It did not properly sanitize or wrap fields to prevent formula execution or handle fields containing quotes or commas correctly.
+**Prevention:** Always sanitize CSV fields. Wrap all values in double quotes, escape existing double quotes by replacing `"` with `""`, and prepend a single quote (`'`) to any value starting with an executable prefix (`=`, `+`, `-`, `@`, `\t`, `\r`).

--- a/src/app/domain/schema-management/components/results-grid.component.ts
+++ b/src/app/domain/schema-management/components/results-grid.component.ts
@@ -354,6 +354,16 @@ export class ResultsGridComponent {
     return !!(this.filterState()[column]);
   }
 
+  /** Sanitizes a field to prevent CSV Injection and properly escapes quotes/commas. */
+  private sanitizeCsvField(value: string | number | null | undefined): string {
+    if (value === null || value === undefined) return '""';
+    let str = String(value);
+    if (/^[=+\-@\t\r]/.test(str)) {
+      str = "'" + str;
+    }
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+
   /** Sanitizes a string for use in filenames by replacing invalid characters with underscores. */
   private sanitizeFilename(s: string): string {
     return s.replace(/[^A-Za-z0-9._-]/g, '_').trim();
@@ -413,8 +423,8 @@ export class ResultsGridComponent {
       `# PRNG Seed: ${data.metadata.seed}`,
       `# SHA-256 Audit Hash: ${data.metadata.auditHash}`,
       methodologyComments,
-      headers.join(','),
-      ...rows.map(e => e.join(','))
+      headers.map(h => this.sanitizeCsvField(h)).join(','),
+      ...rows.map(e => e.map(v => this.sanitizeCsvField(v)).join(','))
     ].join('\n');
 
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: User-controlled fields exported to CSV could start with characters like `=`, `+`, `-`, or `@`. Spreadsheet applications (like Excel or Google Sheets) evaluate these cells as formulas automatically, which could result in data exfiltration or arbitrary local command execution on the user's machine. Also, lack of proper quote escaping could break CSV structure or lead to injection of new columns.
🎯 Impact: High risk of local machine compromise or unexpected data alterations if an exported CSV containing malicious payload is opened.
🔧 Fix: Implemented `sanitizeCsvField` in `ResultsGridComponent` which evaluates values and prepends a single quote (`'`) to any string matching the `/^[=+\-@\t\r]/` regex. Additionally, all field values are wrapped in double quotes, and any internal double quotes are escaped as `""`.
✅ Verification: Ran `pnpm lint` and `npx vitest run src/app` successfully. Evaluated formula injection edge cases.

---
*PR created automatically by Jules for task [15130399452661392304](https://jules.google.com/task/15130399452661392304) started by @fderuiter*