### PR TITLE
🎨 Palette: [UX improvement] Enhance tag input remove button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-05-20 - Drag Handle Affordance
 **Learning:** When implementing drag handles for sortable list items in the UI, relying on simple text characters (like `⋮⋮`) lacks sufficient visual cues for interactivity and accessibility. Users benefit from multiple layered affordances.
 **Action:** Use an SVG icon button with CSS classes for `cursor-grab`, `active:cursor-grabbing`, an explicit `aria-label`, a `title` attribute, and distinct `focus-visible` styling to ensure visual affordance and keyboard accessibility.
+## 2026-05-25 - Focus-Visible on Remove Buttons
+**Learning:** Icon-only remove buttons (like "×" on tags) often lack sufficient keyboard focus indicators, making navigation difficult for screen reader or keyboard users.
+**Action:** Always add `focus-visible:ring-2`, a `title` attribute for native tooltips, and explicit `[attr.aria-label]` to such buttons.

--- a/src/app/domain/study-builder/components/tag-input.component.ts
+++ b/src/app/domain/study-builder/components/tag-input.component.ts
@@ -29,8 +29,9 @@ import { Subscription } from 'rxjs';
           <button
             type="button"
             (click)="removeTag(tag); $event.stopPropagation()" (keydown.enter)="removeTag(tag); $event.stopPropagation()" tabindex="0"
-            class="ml-0.5 text-indigo-500 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 focus:outline-none leading-none font-bold"
+            class="ml-0.5 text-indigo-500 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 rounded-sm leading-none font-bold"
             [attr.aria-label]="'Remove ' + tag"
+            [attr.title]="'Remove ' + tag"
           >×</button>
         </span>
       }


### PR DESCRIPTION
**What:** 
Added a native hover tooltip (`[attr.title]`) and `focus-visible` styling to the tag remove buttons in the `TagInputComponent`.

**Why:**
Icon-only buttons (like the small "×" to remove tags) need a hover affordance for mouse users and explicit, distinct visual indicators when focused via keyboard to improve accessibility and general UX.

**Accessibility:**
Improved keyboard navigation visibility by adding `focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 rounded-sm`. Added a native tooltip using the `title` attribute for mouse users.

**Before/After:**
- **Before:** The "×" button had no hover tooltip and relied only on browser default focus rings which were difficult to see.
- **After:** The button shows a tooltip ("Remove [tag]") on hover and displays a prominent indigo ring when navigated to via keyboard.

---
*PR created automatically by Jules for task [12834140321219404633](https://jules.google.com/task/12834140321219404633) started by @fderuiter*