### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix CSV Injection vulnerability

### DIFF
--- a/src/app/domain/schema-management/components/results-grid.component.ts
+++ b/src/app/domain/schema-management/components/results-grid.component.ts
@@ -367,6 +367,26 @@ export class ResultsGridComponent {
     return `${yyyy}${mm}${dd}`;
   }
 
+  /**
+   * Sanitizes a value for CSV export to prevent Formula Injection (CSV Injection).
+   * It escapes double quotes, wraps the value in double quotes, and prepends a single
+   * quote if the value starts with an executable prefix.
+   */
+  private sanitizeCsvValue(value: string | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '""';
+    }
+    const strValue = String(value);
+    const escapedValue = strValue.replace(/"/g, '""');
+
+    // Check for formula injection prefixes
+    if (/^[=+\-@\t\r]/.test(escapedValue)) {
+      return `"'${escapedValue}"`;
+    }
+
+    return `"${escapedValue}"`;
+  }
+
   /** Copies the audit hash to the clipboard and briefly shows a ✓ icon. */
   copyAuditHash(): void {
     const hash = this.state.results()?.metadata.auditHash;
@@ -384,7 +404,8 @@ export class ResultsGridComponent {
     if (!data) return;
 
     const strataHeaders = data.metadata.strata?.map(s => s.name || s.id) || [];
-    const headers = ['Subject ID', 'Site', ...strataHeaders, 'Block Number', 'Block Size', 'Treatment Arm'];
+    const headers = ['Subject ID', 'Site', ...strataHeaders, 'Block Number', 'Block Size', 'Treatment Arm']
+      .map(h => this.sanitizeCsvValue(h));
 
     const rows = data.schema.map(r => {
       const strataValues = data.metadata.strata?.map(s => r.stratum[s.id] || '') || [];
@@ -395,7 +416,7 @@ export class ResultsGridComponent {
         r.blockNumber.toString(),
         r.blockSize.toString(),
         this.isUnblinded() ? r.treatmentArm : '*** BLINDED ***'
-      ];
+      ].map(val => this.sanitizeCsvValue(val));
     });
 
     const watermark = "DRAFT SCHEMA - DO NOT USE FOR ENROLLMENT. Execute the generated R/SAS/Python script to generate the official trial schema.";


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix CSV Injection vulnerability

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: CSV Injection (Formula Injection)
The CSV export functionality was joining values directly without sanitization. If an exported user-controlled field like "Treatment Arm" began with a formula injection character (such as `=`), opening the file in Excel or other spreadsheet programs could result in unexpected formula execution or external data exfiltration.

### 🎯 Impact:
Spreadsheet applications could execute arbitrary commands leading to information disclosure or potential RCE on the user's machine if the user clicks through security prompts upon opening the downloaded CSV.

### 🔧 Fix:
- Added `sanitizeCsvValue` which wraps all values in double quotes, escapes existing double quotes, and strictly checks for formula prefixes (`=`, `+`, `-`, `@`, `\t`, `\r`).
- If an injection character is detected at the start, a single quote (`'`) is prepended to force the spreadsheet to interpret the cell as text instead of a formula.

### ✅ Verification:
- Automated tests executed successfully (`npx vitest run src/app` and `npx playwright test tests_e2e`).
- Tested locally that standard fields behave correctly and potential formula injections are safely quoted.

---
*PR created automatically by Jules for task [124912390840208770](https://jules.google.com/task/124912390840208770) started by @fderuiter*