### PR TITLE
test(randomization-engine): add boundary tests for empty and zero-input schema generation

### DIFF
--- a/src/app/domain/randomization-engine/core/randomization-algorithm.spec.ts
+++ b/src/app/domain/randomization-engine/core/randomization-algorithm.spec.ts
@@ -630,6 +630,28 @@ describe('generateRandomizationSchema – hierarchical block strategy', () => {
     });
   });
 
+  describe('Boundary Cases', () => {
+    it('generates an unstratified schema when strata is empty', () => {
+      const config: RandomizationConfig = { ...BASE_CONFIG, strata: [] };
+      const result = generateRandomizationSchema(config);
+      expect(result.schema).toBeTruthy();
+      expect(result.schema.length).toBeGreaterThan(0);
+      result.schema.forEach(row => {
+        expect(row.stratumCode).toBe('');
+      });
+    });
+
+    it('throws when arm count is zero', () => {
+      const config: RandomizationConfig = { ...BASE_CONFIG, arms: [] };
+      expect(() => generateRandomizationSchema(config)).toThrow('Total arm ratio must be greater than zero');
+    });
+
+    it('throws when block sizes are empty', () => {
+      const config: RandomizationConfig = { ...BASE_CONFIG, blockSizes: [] };
+      expect(() => generateRandomizationSchema(config)).toThrow('At least one block size must be configured');
+    });
+  });
+
   describe('Validation', () => {
     it('throws when globalBlockStrategy has a size not divisible by totalRatio', () => {
       const config: RandomizationConfig = {

--- a/src/app/domain/randomization-engine/core/randomization-algorithm.ts
+++ b/src/app/domain/randomization-engine/core/randomization-algorithm.ts
@@ -399,9 +399,17 @@ export function generateRandomizationSchema(config: RandomizationConfig): Random
   // Calculate total ratio sum
   const totalRatio = resolvedConfig.arms.reduce((sum, arm) => sum + arm.ratio, 0);
 
+  if (totalRatio === 0) {
+    throw new Error('Total arm ratio must be greater than zero');
+  }
+
   // Validate block sizes from all rules (skip for minimization - block sizes don't apply).
   if (resolvedConfig.randomizationMethod !== 'MINIMIZATION') {
-    for (const size of collectAllBlockSizes(resolvedConfig)) {
+    const allSizes = collectAllBlockSizes(resolvedConfig);
+    if (allSizes.length === 0) {
+      throw new Error('At least one block size must be configured');
+    }
+    for (const size of allSizes) {
       if (size % totalRatio !== 0) {
         throw new Error(`Block size ${size} is not a multiple of total ratio ${totalRatio}`);
       }


### PR DESCRIPTION
No tests verify behavior when schema inputs are empty or zero-valued. 
 
## Acceptance criteria 
- Tests cover empty strata, zero arm count, and zero block sizes. 
- All edge inputs produce deterministic, documented failure or safe output. 

This commit explicitly handles empty arms by throwing a "Total arm ratio must be greater than zero" error and missing block sizes by throwing an "At least one block size must be configured" error. Boundary tests are introduced.

---
*PR created automatically by Jules for task [12153871590029968507](https://jules.google.com/task/12153871590029968507) started by @fderuiter*