### PR TITLE
Add generated-code provenance and version metadata validation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,46 @@ jobs:
     - name: Run Stata static syntax validator
       run: node scripts/validate-stata-syntax.mjs
 
+  metadata_validation:
+    runs-on: ubuntu-latest
+    needs: code_generation_fixtures
+    permissions:
+      contents: read
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411
+      with:
+        egress-policy: audit
+        allowed-endpoints: |-
+          github.com:443
+          api.github.com:443
+          objects.githubusercontent.com:443
+          registry.npmjs.org:443
+          registry.yarnpkg.com:443
+          nodejs.org:443
+          *.blob.core.windows.net:443
+          *.actions.githubusercontent.com:443
+          playwright.azureedge.net:443
+          archive.ubuntu.com:80
+          security.ubuntu.com:80
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+    - name: Set up Node.js
+      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+      with:
+        node-version: '22'
+
+    - name: Download code-generation fixture scripts
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
+      with:
+        name: code-generation-fixtures
+        path: artifacts/code-generation-fixtures/
+
+    - name: Run metadata validation
+      run: node scripts/validate-metadata.mjs
+
   merge_reports:
     runs-on: ubuntu-latest
     needs: e2e
@@ -428,7 +468,7 @@ jobs:
 
   traceability_matrix:
     runs-on: ubuntu-latest
-    needs: [setup, merge_reports, python_script_execution_check, sas_static_validation, stata_static_validation, cross_env_equivalence, sbom, security_scan, lint_actions]
+    needs: [setup, merge_reports, python_script_execution_check, sas_static_validation, stata_static_validation, metadata_validation, cross_env_equivalence, sbom, security_scan, lint_actions]
     if: !cancelled() && needs.setup.result == 'success'
     permissions:
       contents: read
@@ -881,7 +921,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [setup, e2e, code_generation_fixtures, python_script_execution_check, sas_static_validation, stata_static_validation, merge_reports, traceability_matrix, script_validation_report, cross_env_equivalence, sbom, security_scan, lint_actions]
+    needs: [setup, e2e, code_generation_fixtures, python_script_execution_check, sas_static_validation, stata_static_validation, metadata_validation, merge_reports, traceability_matrix, script_validation_report, cross_env_equivalence, sbom, security_scan, lint_actions]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: write

--- a/scripts/validate-metadata.mjs
+++ b/scripts/validate-metadata.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * scripts/validate-metadata.mjs
+ *
+ * Automated metadata and provenance validator for all generated scripts.
+ *
+ * Scans artifacts/code-generation-fixtures/ for:
+ *  - .py (Python)
+ *  - .R (R)
+ *  - .sas (SAS)
+ *  - .do (Stata)
+ *
+ * Asserts each contains:
+ *  1. Protocol ID
+ *  2. App Version (vX.Y.Z)
+ *  3. Generated At (ISO 8601)
+ *  4. Algorithm description
+ *
+ * Exit code 0 if all files pass.
+ * Exit code 1 if any file is missing metadata or malformed.
+ */
+
+import { readdir, readFile } from 'fs/promises';
+import { join, resolve } from 'path';
+
+const FIXTURE_ROOT = resolve(process.cwd(), 'artifacts', 'code-generation-fixtures');
+
+const EXPECTED_METADATA = [
+  { label: 'Protocol field',       re: /Protocol:\s+\S+/i },
+  { label: 'App Version field',    re: /App Version:\s+v\d+\.\d+\.\d+/i },
+  { label: 'Generated At field',   re: /Generated At:\s*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/i },
+  { label: 'Algorithm field',      re: /(Algorithm|PRNG Algorithm):\s+.+/i },
+];
+
+async function collectGeneratedFiles(dir) {
+  const files = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectGeneratedFiles(full));
+    } else if (entry.isFile()) {
+      const ext = entry.name.split('.').pop().toLowerCase();
+      if (['py', 'r', 'sas', 'do'].includes(ext)) {
+        files.push(full);
+      }
+    }
+  }
+  return files;
+}
+
+async function validateMetadata(filePath) {
+  const content = await readFile(filePath, 'utf-8');
+  const errors = [];
+
+  for (const { label, re } of EXPECTED_METADATA) {
+    if (!re.test(content)) {
+      errors.push(`Missing or malformed ${label}`);
+    }
+  }
+  return errors;
+}
+
+async function main() {
+  console.log('--- Generated Code Metadata & Provenance Validator ---');
+  console.log(`Scanning: ${FIXTURE_ROOT}`);
+
+  const files = await collectGeneratedFiles(FIXTURE_ROOT);
+  if (files.length === 0) {
+    console.error('ERROR: No generated scripts found in fixture root.');
+    process.exit(1);
+  }
+
+  console.log(`Found ${files.length} scripts to validate.\n`);
+
+  let totalErrors = 0;
+  for (const file of files) {
+    const rel = file.replace(process.cwd() + '/', '');
+    const errors = await validateMetadata(file);
+    if (errors.length === 0) {
+      console.log(`  ✓  ${rel}`);
+    } else {
+      console.log(`  ✗  ${rel} — ${errors.length} error(s):`);
+      errors.forEach(err => console.log(`       - ${err}`));
+      totalErrors += errors.length;
+    }
+  }
+
+  console.log('\n--- Result ---');
+  if (totalErrors > 0) {
+    console.log(`METADATA_CHECK: FAIL — ${totalErrors} error(s) total.`);
+    process.exit(1);
+  } else {
+    console.log(`METADATA_CHECK: PASS — all ${files.length} scripts have valid metadata headers.`);
+    process.exit(0);
+  }
+}
+
+main().catch(err => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/scripts/validate-stata-syntax.mjs
+++ b/scripts/validate-stata-syntax.mjs
@@ -10,10 +10,32 @@ import { join, resolve } from 'path';
 
 const FIXTURE_ROOT = resolve(process.cwd(), 'artifacts', 'code-generation-fixtures');
 
+const REQUIRED_HEADER_PATTERNS = [
+  { label: 'title comment',        re: /^\*\s*(Randomization Schema Configuration)\s*/i },
+  { label: 'Protocol field',       re: /^\*\s*Protocol:/i },
+  { label: 'App Version field',    re: /^\*\s*App Version:/i },
+  { label: 'Generated At field',   re: /^\*\s*Generated At:/i },
+  { label: 'PRNG\/Algorithm field', re: /^\*\s*(PRNG Algorithm|Algorithm):/i },
+];
+
+const ISO_TIMESTAMP_RE = /Generated At:\s*(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})/i;
+
 async function validateFile(filePath) {
   const src = await readFile(filePath, 'utf-8');
   const errors = [];
   const lines = src.split('\n');
+
+  // Header validation
+  for (const { label, re } of REQUIRED_HEADER_PATTERNS) {
+    if (!lines.some(line => re.test(line))) {
+      errors.push(`Missing required header field: ${label}`);
+    }
+  }
+
+  const tsMatch = src.match(ISO_TIMESTAMP_RE);
+  if (!tsMatch) {
+    errors.push(`Missing or malformed "Generated At" ISO 8601 timestamp`);
+  }
 
   lines.forEach((line, idx) => {
     // Check for common Stata macro dereferencing errors

--- a/src/app/domain/schema-management/services/generation/ir/transpiler.spec.ts
+++ b/src/app/domain/schema-management/services/generation/ir/transpiler.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { CodeTranspiler } from './transpiler';
+import { RandomizationConfig } from '../../../../core/models/randomization.model';
+
+describe('CodeTranspiler Metadata Validation', () => {
+  const mockConfig: RandomizationConfig = {
+    protocolId: 'TEST-PROT-001',
+    studyName: 'Test Study',
+    phase: 'Phase I',
+    arms: [{ id: 'A', name: 'Arm A', ratio: 1 }],
+    sites: ['Site 1'],
+    strata: [],
+    blockSizes: [2],
+    stratumCaps: [{ levels: [], cap: 4 }],
+    seed: 'test-seed',
+    subjectIdMask: '{SITE}-{SEQ:3}',
+    randomizationMethod: 'PERMUTED_BLOCK'
+  };
+
+  const languages = ['R', 'Python', 'SAS', 'STATA'] as const;
+
+  languages.forEach(lang => {
+    describe(`${lang} Metadata`, () => {
+      it(`should contain the expected version header and provenance for ${lang}`, () => {
+        const code = CodeTranspiler.transpile(lang, mockConfig, 'BLOCK');
+
+        // Assert Protocol ID
+        expect(code).toContain('Protocol: TEST-PROT-001');
+
+        // Assert App Version
+        expect(code).toMatch(/App Version: v\d+\.\d+\.\d+/);
+
+        // Assert Generated At (ISO 8601 subset check)
+        expect(code).toMatch(/Generated At: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+        // Assert Algorithm
+        expect(code).toContain('Algorithm: PRNG Algorithm: MT19937');
+      });
+    });
+  });
+
+  it('should contain Minimization algorithm metadata when transpiling minimization', () => {
+    const minConfig = {
+      ...mockConfig,
+      randomizationMethod: 'MINIMIZATION',
+      blockSizes: [],
+      globalBlockStrategy: undefined,
+      siteBlockOverrides: undefined,
+      stratumBlockOverrides: undefined
+    } as RandomizationConfig;
+    const code = CodeTranspiler.transpile('Python', minConfig, 'MINIMIZATION');
+    expect(code).toContain('Algorithm: Pocock-Simon Minimization');
+  });
+});


### PR DESCRIPTION
Added comprehensive metadata and provenance validation for generated scripts. This include unit tests for the transpiler and a new CI job that validates the generated artifacts for Protocol ID, App Version, ISO 8601 timestamp, and algorithm details across Python, R, SAS, and Stata.

Fixes #334

---
*PR created automatically by Jules for task [4563076806528948049](https://jules.google.com/task/4563076806528948049) started by @fderuiter*