### PR TITLE
Add string-escaping tests and fixes for generated Python scripts

### DIFF
--- a/src/app/domain/schema-management/services/generation/ir/transpiler.spec.ts
+++ b/src/app/domain/schema-management/services/generation/ir/transpiler.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { CodeTranspiler } from './transpiler';
 import { RandomizationConfig } from '../../../../core/models/randomization.model';
+import { execSync } from 'child_process';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 describe('CodeTranspiler Metadata Validation', () => {
   const mockConfig: RandomizationConfig = {
@@ -50,5 +54,56 @@ describe('CodeTranspiler Metadata Validation', () => {
     } as RandomizationConfig;
     const code = CodeTranspiler.transpile('Python', minConfig, 'MINIMIZATION');
     expect(code).toContain('Algorithm: Pocock-Simon Minimization');
+  });
+
+  describe('Python String Escaping and Execution', () => {
+    it('should generate syntactically valid Python even with special characters in metadata and strata', () => {
+      const weirdConfig: RandomizationConfig = {
+        protocolId: 'PROT"-$METACH-$(echo)',
+        studyName: 'Study with "Quotes" and \\Backslashes\\',
+        phase: 'Phase I',
+        arms: [
+          { id: 'A', name: 'Arm "A" (Alpha)', ratio: 1 },
+          { id: 'B', name: "Arm 'B' (Beta)", ratio: 1 }
+        ],
+        sites: ['Site "1"', 'Site \\2\\'],
+        strata: [
+          {
+            id: 'Factor"With"Quotes',
+            levels: ['Level "1"', "Level '2'", 'Level\\With\\Backslash', 'Unicode-α-Ω']
+          }
+        ],
+        blockSizes: [2, 4],
+        stratumCaps: [
+          { levelIds: { 'Factor"With"Quotes': 'Level "1"' }, cap: 2 },
+          { levelIds: { 'Factor"With"Quotes': "Level '2'" }, cap: 2 }
+        ],
+        seed: 'seed-with-"quotes"',
+        subjectIdMask: '{SITE}-{STRATUM}-{SEQ:3}',
+        randomizationMethod: 'BLOCK'
+      };
+
+      const code = CodeTranspiler.transpile('Python', weirdConfig, 'BLOCK');
+
+      // Basic assertions that escaping is happening for some known fields
+      expect(code).toContain('Arm \\"A\\" (Alpha)');
+      expect(code).toContain('Factor\\"With\\"Quotes');
+
+      const tmpFile = join(tmpdir(), `test_generated_${Date.now()}.py`);
+      try {
+        writeFileSync(tmpFile, code);
+        // We expect this to pass if the syntax is valid.
+        // We use python3 -m py_compile to check syntax without full execution if preferred,
+        // but the plan says "executes without errors".
+        // The generated script needs numpy and pandas.
+        execSync(`python3 ${tmpFile}`, { stdio: 'pipe' });
+      } catch (error: any) {
+        const stderr = error.stderr?.toString() || '';
+        const stdout = error.stdout?.toString() || '';
+        throw new Error(`Python execution failed.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}\nCODE:\n${code}`);
+      } finally {
+        try { unlinkSync(tmpFile); } catch {}
+      }
+    });
   });
 });

--- a/src/app/domain/schema-management/services/generation/ir/transpiler.ts
+++ b/src/app/domain/schema-management/services/generation/ir/transpiler.ts
@@ -102,7 +102,7 @@ export class CodeTranspiler {
       for (const row of schema) {
          schemaRows += `  {"SubjectID": "${FormattingUtil.escapePythonString(row.subjectId)}", "Site": "${FormattingUtil.escapePythonString(row.site)}", "Treatment": "${FormattingUtil.escapePythonString(row.treatmentArm)}", "BlockNumber": ${row.blockNumber}, "BlockSize": ${row.blockSize}, "StratumCode": "${FormattingUtil.escapePythonString(row.stratumCode)}"`;
          for (const s of config.strata || []) {
-             schemaRows += `, "${s.id}": "${FormattingUtil.escapePythonString(row.stratum[s.id])}"`;
+             schemaRows += `, "${FormattingUtil.escapePythonString(s.id)}": "${FormattingUtil.escapePythonString(row.stratum[s.id])}"`;
          }
          schemaRows += `},\n`;
       }
@@ -165,7 +165,7 @@ export class CodeTranspiler {
         for (const task of ir.tasks) {
           let extraStrata = '';
           for (const s of config.strata || []) {
-            extraStrata += `, "${s.id}": "${FormattingUtil.escapePythonString(task.stratumDetails[s.id])}"`;
+            extraStrata += `, "${FormattingUtil.escapePythonString(s.id)}": "${FormattingUtil.escapePythonString(task.stratumDetails[s.id])}"`;
           }
 
           algorithmicLogic += `count = 0\n`;
@@ -189,7 +189,7 @@ export class CodeTranspiler {
       
       let strataComments = '';
       (config.strata || []).forEach(s => {
-          strataComments += `# Stratum: ${s.id}, Levels: ${s.levels.map(l => FormattingUtil.escapePythonString(l)).join(', ')}\n`;
+          strataComments += `# Stratum: ${FormattingUtil.escapePythonString(s.id)}, Levels: ${s.levels.map(l => FormattingUtil.escapePythonString(l)).join(', ')}\n`;
       });
       data['strataComments'] = strataComments.trimEnd();
       data['minimizationParam'] = method === 'MINIMIZATION' ? `p_minimization = ${config.minimizationConfig?.p || 0.8} # maintain precision parity` : '';


### PR DESCRIPTION
This change addresses the issue where generated Python scripts were not tested against special characters in variable names or stratum labels.

Key changes:
1.  **Transpiler Fixes**: Updated `src/app/domain/schema-management/services/generation/ir/transpiler.ts` to use `FormattingUtil.escapePythonString` for stratum factor IDs when they are used as dictionary keys in both the static and algorithmic code generation paths.
2.  **Improved Comments**: Ensured stratum labels in Python comments are also escaped.
3.  **Comprehensive Testing**: Added a new test suite in `src/app/domain/schema-management/services/generation/ir/transpiler.spec.ts` that:
    - Uses a configuration with various special characters (single/double quotes, backslashes, Unicode, and shell metacharacters).
    - Verifies that the generated Python code contains the expected escaped strings.
    - Successfully executes the generated script using `python3` to confirm syntactic validity and runtime correctness.

All unit tests passed.

Fixes #288

---
*PR created automatically by Jules for task [14336786116062403411](https://jules.google.com/task/14336786116062403411) started by @fderuiter*