### PR TITLE
Add tag-input paste-parsing test coverage

### DIFF
--- a/src/app/domain/study-builder/components/tag-input.component.spec.ts
+++ b/src/app/domain/study-builder/components/tag-input.component.spec.ts
@@ -101,11 +101,30 @@ describe('TagInputComponent', () => {
       expect(component.control.value).toBe('Site A, Site B, Site C');
     });
 
-    it('should skip pasted duplicate values when splitting comma-separated input', () => {
-      component.tags = ['Site A'];
-      component.inputValue = 'Site A, Site B';
+    it('should split newline-separated pasted values into individual tags', () => {
+      component.inputValue = 'Site A\nSite B\r\nSite C';
       component.commitInput();
-      expect(component.tags).toEqual(['Site A', 'Site B']);
+      expect(component.tags).toEqual(['Site A', 'Site B', 'Site C']);
+      expect(component.control.value).toBe('Site A, Site B, Site C');
+    });
+
+    it('should handle mixed comma and newline separators', () => {
+      component.inputValue = 'Site A, Site B\nSite C,Site D';
+      component.commitInput();
+      expect(component.tags).toEqual(['Site A', 'Site B', 'Site C', 'Site D']);
+    });
+
+    it('should skip pasted duplicate values and handle duplicates within the paste', () => {
+      component.tags = ['Site A'];
+      component.inputValue = 'Site A, Site B, Site B, Site C';
+      component.commitInput();
+      expect(component.tags).toEqual(['Site A', 'Site B', 'Site C']);
+    });
+
+    it('should handle empty-string tokens from consecutive separators', () => {
+      component.inputValue = 'Site A,,Site B\n\nSite C';
+      component.commitInput();
+      expect(component.tags).toEqual(['Site A', 'Site B', 'Site C']);
     });
 
     it('should not add an empty tag', () => {

--- a/src/app/domain/study-builder/components/tag-input.component.ts
+++ b/src/app/domain/study-builder/components/tag-input.component.ts
@@ -110,12 +110,12 @@ export class TagInputComponent implements OnInit, OnDestroy {
   }
 
   commitInput(): void {
-    const rawVal = this.inputValue.trim().replace(/,+$/, '');
+    const rawVal = this.inputValue.trim();
     if (rawVal) {
       const newTags = rawVal
-        .split(',')
+        .split(/[,\n\r]+/)
         .map(t => t.trim())
-        .filter(t => t && !this.tags.includes(t));
+        .filter((t, index, self) => t && !this.tags.includes(t) && self.indexOf(t) === index);
       if (newTags.length > 0) {
         this.tags = [...this.tags, ...newTags];
         this.update();


### PR DESCRIPTION
This PR adds comprehensive test coverage for the tag input's paste behavior, ensuring it correctly handles comma and newline separators, avoids duplicate values (including those within the pasted string), and skips empty tokens.

Key changes:
- Modified `TagInputComponent.commitInput()` to use a regex for splitting (`/[,\n\r]+/`).
- Improved the filtering logic in `commitInput()` to remove duplicates from the newly pasted tags themselves.
- Added 3 new test cases and enhanced 2 existing ones in `tag-input.component.spec.ts` to cover the required scenarios.

Fixes #297

---
*PR created automatically by Jules for task [12857511131778305798](https://jules.google.com/task/12857511131778305798) started by @fderuiter*