### PR TITLE
Fix STATA code generation validation regex

### DIFF
--- a/src/app/domain/schema-management/services/generation/static-mapping.guard.spec.ts
+++ b/src/app/domain/schema-management/services/generation/static-mapping.guard.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { StaticMappingGuard } from './static-mapping.guard';
+import { RandomizationConfig } from '../../../core/models/randomization.model';
+
+describe('StaticMappingGuard STATA Orphaned Variables', () => {
+  const mockConfig: RandomizationConfig = {
+    protocolId: 'Simulation',
+    seed: '009f22b3edf94168e8b39bf218527051',
+    arms: [
+      { id: 'A', name: 'Active', ratio: 1 },
+      { id: 'B', name: 'Placebo', ratio: 1 },
+    ],
+    sites: ['101'],
+    strata: [
+      {
+        id: 'age',
+        name: 'Age Group',
+        levels: ['<65', '>=65'],
+      },
+    ],
+    blockSizes: [4],
+    randomizationMethod: 'BLOCK',
+  } as any;
+
+  it('should catch orphaned treatment arms', () => {
+    const seedHash = "1530624355";
+    const output = `
+* Randomization Schema Configuration
+set seed ${seedHash}
+local arm_name_1 \`"Active"'
+local arm_name_2 \`"Placebo"'
+local arm_name_3 \`"OrphanedArm"'
+local strata_1 \`"age"'
+* Level: \`"<65"'
+* Level: \`">=65"'
+* Ratios: 1, 1
+
+replace SubjectID=\`"SIM-101-AGE-001"' in 1
+replace Site=\`"101"' in 1
+replace Treatment=\`"Active"' in 1
+replace BlockNumber=1 in 1
+replace BlockSize=4 in 1
+replace StratumCode=\`"AGE"' in 1
+replace age=\`"<65"' in 1
+    `;
+
+    // This is expected to fail (not throw) because the regex is currently broken and won't find arm_name_3
+    expect(() => StaticMappingGuard.verify('STATA', mockConfig, output)).toThrow(/Orphaned variable: Treatment arm "OrphanedArm"/);
+  });
+
+  it('should catch orphaned strata', () => {
+    const seedHash = "1530624355";
+    const output = `
+* Randomization Schema Configuration
+set seed ${seedHash}
+local arm_name_1 \`"Active"'
+local arm_name_2 \`"Placebo"'
+local strata_1 \`"age"'
+local strata_2 \`"orphaned_strata"'
+* Level: \`"<65"'
+* Level: \`">=65"'
+* Ratios: 1, 1
+
+replace SubjectID=\`"SIM-101-AGE-001"' in 1
+replace Site=\`"101"' in 1
+replace Treatment=\`"Active"' in 1
+replace BlockNumber=1 in 1
+replace BlockSize=4 in 1
+replace StratumCode=\`"AGE"' in 1
+replace age=\`"<65"' in 1
+    `;
+
+    // This is expected to fail because the regex is currently broken
+    expect(() => StaticMappingGuard.verify('STATA', mockConfig, output)).toThrow(/Orphaned variable: Stratum "orphaned_strata"/);
+  });
+});

--- a/src/app/domain/schema-management/services/generation/static-mapping.guard.ts
+++ b/src/app/domain/schema-management/services/generation/static-mapping.guard.ts
@@ -85,7 +85,7 @@ export class StaticMappingGuard {
         }
       }
     } else if (language === 'STATA') {
-      const armDefs = [...output.matchAll(/local arm_name_\d+\s+(?:"\`"|")([^"]+)(?:"'"|")/g)].map(m => m[1]);
+      const armDefs = [...output.matchAll(/local arm_name_\d+\s+(?:\x60\"|")([^"]+)(?:\"\'|")/g)].map(m => m[1]);
       const schemaArms = config.arms.map(a => a.name);
       for (const da of armDefs) {
         if (!schemaArms.includes(da)) {
@@ -93,7 +93,7 @@ export class StaticMappingGuard {
         }
       }
 
-      const strataDefs = [...output.matchAll(/local strata_\d+\s+(?:"\`"|")([^"]+)(?:"'"|")/g)].map(m => m[1]);
+      const strataDefs = [...output.matchAll(/local strata_\d+\s+(?:\x60\"|")([^"]+)(?:\"\'|")/g)].map(m => m[1]);
       const schemaStrata = (config.strata || []).map(s => s.id);
       for (const ds of strataDefs) {
         // Stata ID may be sanitized in the generated output, so we need to sanitize schemaStrata to compare


### PR DESCRIPTION
Fixed a bug in STATA code generation validation where incorrect regular expressions caused mapping mismatch errors due to failing to parse STATA's compound quotes correctly. Added regression tests.

Fixes #485

---
*PR created automatically by Jules for task [15282383282898211312](https://jules.google.com/task/15282383282898211312) started by @fderuiter*