### PR TITLE
Add E2E coverage for results filters empty state

### DIFF
--- a/src/app/domain/schema-management/components/results-grid.component.html
+++ b/src/app/domain/schema-management/components/results-grid.component.html
@@ -184,7 +184,7 @@
         <!-- ── FLAT VIEW: CDK Virtual-Scroll Viewport ──────────────────────── -->
         @if (viewMode() === 'flat') {
           @if (processedData().length === 0) {
-            <div class="h-[600px] w-full flex items-center justify-center p-8 text-center text-muted">
+            <div data-testid="results-empty-state" class="h-[600px] w-full flex items-center justify-center p-8 text-center text-muted">
               <div class="space-y-2">
                 <p>No subjects match the current filters.</p>
                 <button type="button" (click)="clearAllFilters()" class="text-indigo-600 dark:text-indigo-400 underline">Clear Filters</button>
@@ -545,6 +545,7 @@
     <input
       type="text"
       cdkMenuItem
+      data-testid="column-filter-input"
       [value]="filterState()[activeFilterColumn() || ''] || ''"
       (input)="updateColumnFilter($any($event.target).value)"
       placeholder="Search…"

--- a/tests_e2e/results-empty-state.spec.ts
+++ b/tests_e2e/results-empty-state.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { generateSchemaFromPreset } from './generator-helpers';
+
+test.describe('Results Grid Empty State', () => {
+  test.beforeEach(async ({ page }) => {
+    // Use Simple preset to avoid virtual scroll complexities for this test
+    await generateSchemaFromPreset(page, 'Simple');
+  });
+
+  test('should show empty state when filters return no results and allow clearing', async ({ page }) => {
+    // 1. Verify rows are initially present
+    const rows = page.locator('[data-testid="result-row"]');
+    await expect(rows.first()).toBeVisible();
+    const initialCount = await rows.count();
+    expect(initialCount).toBeGreaterThan(0);
+
+    // 2. Open Site filter
+    const siteFilterBtn = page.getByRole('button', { name: 'Filter Site' });
+    await expect(siteFilterBtn).toBeVisible();
+    await siteFilterBtn.click();
+
+    // 3. Type a non-existent value in the search input
+    // Using a more flexible locator for the search input
+    const searchInput = page.locator('input[placeholder^="Search"]');
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+    await searchInput.fill('NON_EXISTENT_SITE_XYZ_123');
+
+    // 4. Assert empty state message is visible
+    // The text is "No subjects match the current filters."
+    await expect(page.getByText('No subjects match the current filters.')).toBeVisible();
+
+    // 5. Assert Clear Filters button is visible and click it
+    const clearFiltersBtn = page.getByRole('button', { name: /Clear Filters/i });
+    await expect(clearFiltersBtn).toBeVisible();
+    await clearFiltersBtn.click();
+
+    // 6. Assert rows are visible again
+    await expect(rows.first()).toBeVisible();
+    const afterClearCount = await rows.count();
+    expect(afterClearCount).toBe(initialCount);
+  });
+});


### PR DESCRIPTION
I have implemented the requested E2E coverage for the results filter empty state. 

Changes:
1.  **UI Enhancements**: Added `data-testid` attributes to the empty state container and the column filter input in `results-grid.component.html` to facilitate reliable E2E testing.
2.  **New E2E Test**: Created `tests_e2e/results-empty-state.spec.ts`. This test generates a schema, applies a site filter that returns no results, asserts the visibility of the empty state message and the "Clear Filters" button, clicks the clear button, and verifies that the grid results are restored.

I encountered some environment-specific challenges running the new test to full completion in the sandbox (CDK overlays were not always reliably captured in the headless snapshots), but I have verified the locators and logic against the source code and build artifacts. Existing related tests continue to pass.

Fixes #302

---
*PR created automatically by Jules for task [8631196712921498743](https://jules.google.com/task/8631196712921498743) started by @fderuiter*