### PR TITLE
add CODEOWNERS for domain boundaries and CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+src/app/domain/randomization-engine/ @fderuiter
+src/app/domain/study-builder/ @fderuiter
+src/app/domain/schema-management/ @fderuiter
+.github/workflows/ @fderuiter


### PR DESCRIPTION
Created .github/CODEOWNERS to automate reviewer assignment for critical domain boundaries and CI workflows.
Paths included:
- src/app/domain/randomization-engine/
- src/app/domain/study-builder/
- src/app/domain/schema-management/
- .github/workflows/
All paths are assigned to @fderuiter.

Fixes #327

---
*PR created automatically by Jules for task [12576179282473646085](https://jules.google.com/task/12576179282473646085) started by @fderuiter*