### PR TITLE
Add issue templates for test-gap and validation-gap reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,6 +12,7 @@ body:
         - Bug
         - Feature
         - Test Gap
+        - Validation Gap
         - Refactor / Tech Debt
         - Release Hardening
       default: 0

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -12,6 +12,7 @@ body:
         - Feature
         - Bug
         - Test Gap
+        - Validation Gap
         - Refactor / Tech Debt
         - Release Hardening
       default: 0

--- a/.github/ISSUE_TEMPLATE/release-hardening.yml
+++ b/.github/ISSUE_TEMPLATE/release-hardening.yml
@@ -13,6 +13,7 @@ body:
         - Bug
         - Feature
         - Test Gap
+        - Validation Gap
         - Refactor / Tech Debt
       default: 0
     validations:

--- a/.github/ISSUE_TEMPLATE/test-gap.yml
+++ b/.github/ISSUE_TEMPLATE/test-gap.yml
@@ -10,6 +10,7 @@ body:
       description: What type of issue is this?
       options:
         - Test Gap
+        - Validation Gap
         - Bug
         - Feature
         - Refactor / Tech Debt
@@ -32,30 +33,23 @@ body:
     validations:
       required: true
   - type: textarea
-    id: expected
+    id: behavior
     attributes:
-      label: Expected Behavior
-      description: What is the expected behavior of the covered code?
+      label: What behavior is untested?
+      description: Describe the functionality that currently lacks test coverage.
     validations:
       required: true
   - type: textarea
-    id: actual
+    id: impact
     attributes:
-      label: Actual Behavior / Gap
-      description: What is the current test coverage gap?
+      label: Why it matters
+      description: What is the risk of this behavior being untested?
     validations:
       required: true
   - type: textarea
-    id: criteria
+    id: suggested-approach
     attributes:
-      label: Acceptance Criteria
-      description: What needs to be done for this issue to be considered resolved?
-    validations:
-      required: true
-  - type: textarea
-    id: test-plan
-    attributes:
-      label: Test Plan
-      description: How will the new tests be verified?
+      label: Suggested test approach
+      description: How should this gap be addressed? (e.g. unit test, integration test, E2E test)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/validation-gap.yml
+++ b/.github/ISSUE_TEMPLATE/validation-gap.yml
@@ -1,7 +1,7 @@
-name: Refactor / Tech Debt
-description: Suggest code improvements and cleanup
-title: "[Refactor]: "
-labels: ["refactor"]
+name: Validation Gap
+description: Report a missing validation coverage
+title: "[Validation Gap]: "
+labels: ["validation-gap"]
 body:
   - type: dropdown
     id: type
@@ -9,11 +9,11 @@ body:
       label: Type
       description: What type of issue is this?
       options:
-        - Refactor / Tech Debt
+        - Validation Gap
+        - Test Gap
         - Bug
         - Feature
-        - Test Gap
-        - Validation Gap
+        - Refactor / Tech Debt
         - Release Hardening
       default: 0
     validations:
@@ -33,30 +33,23 @@ body:
     validations:
       required: true
   - type: textarea
-    id: expected
+    id: behavior
     attributes:
-      label: Expected Behavior
-      description: What should the code look/act like after the refactor?
+      label: What behavior is untested?
+      description: Describe the functionality that currently lacks validation coverage.
     validations:
       required: true
   - type: textarea
-    id: actual
+    id: impact
     attributes:
-      label: Actual Behavior / Gap
-      description: What is the current state of the code or the technical debt?
+      label: Why it matters
+      description: What is the risk of this behavior being unvalidated?
     validations:
       required: true
   - type: textarea
-    id: criteria
+    id: suggested-approach
     attributes:
-      label: Acceptance Criteria
-      description: What needs to be done for this issue to be considered resolved?
-    validations:
-      required: true
-  - type: textarea
-    id: test-plan
-    attributes:
-      label: Test Plan
-      description: How will this change be tested?
+      label: Suggested test approach
+      description: How should this gap be addressed? (e.g. unit test, integration test, E2E test)
     validations:
       required: true


### PR DESCRIPTION
This PR adds structured issue templates for reporting missing test and validation coverage, as requested. The templates capture the following information:
- Area affected (dropdown)
- What behavior is untested
- Why it matters (impact)
- Suggested test approach

Additionally, the "Validation Gap" type has been added to the dropdown menu of all existing issue templates to ensure consistency across the project's issue reporting.

Fixes #329

---
*PR created automatically by Jules for task [1723929400931074838](https://jules.google.com/task/1723929400931074838) started by @fderuiter*