### PR TITLE
Add bundle-size and performance budget checks to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile
 
-    - name: Build Project
+    - name: Build and Enforce Bundle Budgets
       run: pnpm run build
 
     - name: Install Playwright Browsers

--- a/angular.json
+++ b/angular.json
@@ -48,8 +48,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2.5MB",
-                  "maximumError": "3MB"
+                  "maximumWarning": "2.0MB",
+                  "maximumError": "2.2MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/docs/PERFORMANCE_BUDGETS.md
+++ b/docs/PERFORMANCE_BUDGETS.md
@@ -1,0 +1,22 @@
+# Performance Budgets
+
+To ensure that Equipose remains fast and accessible for all users, we enforce bundle size budgets in our CI pipeline.
+
+## Bundle Size Budgets
+
+These budgets are defined in `angular.json` and enforced during the production build (`ng build`).
+
+| Bundle Type | Warning Threshold | Error Threshold | Description |
+| ----------- | ----------------- | --------------- | ----------- |
+| Initial | 2.0 MB | 2.2 MB | The initial payload required to load the application. |
+| Component Styles | 4 kB | 8 kB | Maximum size for any single component's CSS. |
+
+## Rationale
+
+- **Accessibility:** Smaller bundle sizes ensure faster load times on slower networks and devices.
+- **Regression Detection:** Explicit budgets help us catch accidental inclusion of large dependencies or inefficient code changes early in the development cycle.
+- **Maintainability:** Keeping the application lean encourages modular design and efficient use of resources.
+
+## Enforcement
+
+The CI pipeline runs `pnpm run build` as part of the `setup` job. If the bundle size exceeds the `maximumError` threshold, the build will fail, preventing the changes from being merged.


### PR DESCRIPTION
This PR implements bundle-size budget enforcement in the CI pipeline for the Angular production build.

Key changes:
- Modified `angular.json` to set `maximumWarning` to 2.0MB and `maximumError` to 2.2MB for the `initial` bundle.
- Updated `.github/workflows/ci.yml` to rename the build step to "Build and Enforce Bundle Budgets".
- Created a new documentation file `docs/PERFORMANCE_BUDGETS.md` explaining the budgets and their rationale.

I've verified that the current production bundle size (~1.90MB) passes these budgets, and I've also confirmed that a lower budget (e.g., 1.0MB) correctly causes the build to fail in the CI environment. Unit tests were run to ensure no regressions.

Fixes #330

---
*PR created automatically by Jules for task [1826663410660325759](https://jules.google.com/task/1826663410660325759) started by @fderuiter*