### PR TITLE
Add component boundary tests for zero-state and loading-state transitions

### DIFF
--- a/src/app/domain/study-builder/components/generator.component.spec.ts
+++ b/src/app/domain/study-builder/components/generator.component.spec.ts
@@ -232,6 +232,32 @@ describe('GeneratorComponent (domain)', () => {
     expect(el.querySelector('[data-testid="zero-state"]')).toBeTruthy();
   });
 
+  it('state machine transition: Zero -> Generating -> Results', () => {
+    const fixture = TestBed.createComponent(GeneratorComponent);
+    fixture.detectChanges();
+    let el: HTMLElement = fixture.nativeElement;
+
+    // 1. Initial State: Zero-state visible
+    expect(el.querySelector('[data-testid="zero-state"]')).toBeTruthy();
+    expect(el.querySelector('[data-testid="skeleton-grid"]')).toBeFalsy();
+    expect(el.querySelector('#results-section')).toBeFalsy();
+
+    // 2. Start Generating: Skeleton visible
+    mockFacade.isGenerating.set(true);
+    fixture.detectChanges();
+    expect(el.querySelector('[data-testid="zero-state"]')).toBeFalsy();
+    expect(el.querySelector('[data-testid="skeleton-grid"]')).toBeTruthy();
+    expect(el.querySelector('#results-section')).toBeFalsy();
+
+    // 3. Generation Complete: Results visible
+    mockFacade.isGenerating.set(false);
+    mockFacade.results.set(MOCK_RESULT);
+    fixture.detectChanges();
+    expect(el.querySelector('[data-testid="zero-state"]')).toBeFalsy();
+    expect(el.querySelector('[data-testid="skeleton-grid"]')).toBeFalsy();
+    expect(el.querySelector('#results-section')).toBeTruthy();
+  });
+
   // ── Code generator modal ───────────────────────────────────────────────────
 
   it('should render the code generator modal when showCodeGenerator is true and config is set', () => {

--- a/src/app/domain/study-builder/components/skeleton-grid.component.spec.ts
+++ b/src/app/domain/study-builder/components/skeleton-grid.component.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { SkeletonGridComponent } from './skeleton-grid.component';
+import { By } from '@angular/platform-browser';
+
+describe('SkeletonGridComponent', () => {
+  let component: SkeletonGridComponent;
+  let fixture: ComponentFixture<SkeletonGridComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SkeletonGridComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SkeletonGridComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have the animate-pulse class for shimmering effect', () => {
+    const container = fixture.debugElement.query(By.css('[data-testid="skeleton-grid"]'));
+    expect(container.nativeElement.classList.contains('animate-pulse')).toBe(true);
+  });
+
+  it('should have correct accessibility attributes', () => {
+    const container = fixture.debugElement.query(By.css('[data-testid="skeleton-grid"]'));
+    expect(container.nativeElement.getAttribute('aria-busy')).toBe('true');
+    expect(container.nativeElement.getAttribute('aria-label')).toBe('Generating schema…');
+  });
+
+  it('should render the correct number of skeleton rows', () => {
+    const rows = fixture.debugElement.queryAll(By.css('tbody tr'));
+    expect(rows.length).toBe(12);
+  });
+
+  it('should render analytics placeholders', () => {
+    // Donut chart placeholder
+    const donut = fixture.debugElement.query(By.css('.rounded-full.bg-gray-200'));
+    expect(donut).toBeTruthy();
+
+    // Bar chart bars
+    const bars = fixture.debugElement.queryAll(By.css('.flex-1.rounded-t-md'));
+    expect(bars.length).toBe(5);
+  });
+});

--- a/src/app/domain/study-builder/components/zero-state.component.spec.ts
+++ b/src/app/domain/study-builder/components/zero-state.component.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ZeroStateComponent } from './zero-state.component';
+import { By } from '@angular/platform-browser';
+
+describe('ZeroStateComponent', () => {
+  let component: ZeroStateComponent;
+  let fixture: ComponentFixture<ZeroStateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ZeroStateComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ZeroStateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the illustrative SVG', () => {
+    const svg = fixture.debugElement.query(By.css('svg[aria-hidden="true"]'));
+    expect(svg).toBeTruthy();
+  });
+
+  it('should render the correct heading', () => {
+    const heading = fixture.debugElement.query(By.css('h3'));
+    expect(heading.nativeElement.textContent).toContain('No schema generated yet');
+  });
+
+  it('should render the description', () => {
+    const description = fixture.debugElement.query(By.css('p'));
+    expect(description.nativeElement.textContent).toContain('Configure your trial parameters in the form above');
+  });
+
+  it('should emit loadPreset when CTA button is clicked', () => {
+    let emitted = false;
+    component.loadPreset.subscribe(() => (emitted = true));
+
+    const button = fixture.debugElement.query(By.css('[data-testid="load-preset-btn"]'));
+    button.nativeElement.click();
+
+    expect(emitted).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR adds comprehensive unit tests for ZeroStateComponent and SkeletonGridComponent, and introduces a state machine transition test in GeneratorComponent to verify clean transitions between empty, loading, and populated states.

Tests cover:
- ZeroStateComponent: Rendering of SVG, heading, description, and "Load Preset" button emission.
- SkeletonGridComponent: Animation class, aria-busy, and skeleton row/chart rendering.
- GeneratorComponent: A full lifecycle test (Zero -> Generating -> Results) ensuring state mutual exclusivity.

Fixes #301

---
*PR created automatically by Jules for task [14701777531578056848](https://jules.google.com/task/14701777531578056848) started by @fderuiter*