### PR TITLE
Add download UX smoke tests for CSV, PDF, and code exports

### DIFF
--- a/tests_e2e/download-ux.spec.ts
+++ b/tests_e2e/download-ux.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { generateSchemaFromPreset, openGenerator, loadPreset, goToReviewStep } from './generator-helpers';
+
+test.describe('Download UX Smoke Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', err => console.log(`Page Error: ${err.message}`));
+  });
+
+  test('should verify CSV and PDF export buttons in results grid', async ({ page }) => {
+    // 1. Generate a schema using Simple preset
+    await generateSchemaFromPreset(page, 'Simple');
+
+    const resultsSection = page.locator('#results-section');
+    await expect(resultsSection).toBeVisible();
+
+    // 2. Assert CSV button is visible and enabled
+    const csvButton = resultsSection.getByRole('button', { name: /CSV/i });
+    await expect(csvButton).toBeVisible();
+    await expect(csvButton).toBeEnabled();
+
+    // 3. Verify CSV download triggers
+    const csvDownloadPromise = page.waitForEvent('download');
+    await csvButton.click();
+    const csvDownload = await csvDownloadPromise;
+    expect(csvDownload.suggestedFilename()).toMatch(/randomization_.*\.csv$/);
+
+    // 4. Assert PDF button is visible and enabled
+    const pdfButton = resultsSection.getByRole('button', { name: /PDF/i });
+    await expect(pdfButton).toBeVisible();
+    await expect(pdfButton).toBeEnabled();
+
+    // 5. Verify PDF download triggers
+    const pdfDownloadPromise = page.waitForEvent('download');
+    await pdfButton.click();
+    const pdfDownload = await pdfDownloadPromise;
+    expect(pdfDownload.suggestedFilename()).toMatch(/randomization_.*\.pdf$/);
+  });
+
+  test('should verify Code Generator modal UX and download', async ({ page }) => {
+    // 1. Navigate to Review & Generate step
+    await openGenerator(page);
+    await loadPreset(page, 'Simple');
+    await goToReviewStep(page);
+
+    // 2. Open Code Generator dropdown and select R Script
+    const generateCodeBtn = page.getByRole('button', { name: /Generate Code/i });
+    await generateCodeBtn.click();
+    await page.getByRole('menuitem', { name: /R Script/i }).click();
+
+    // 3. Assert modal is visible
+    const modal = page.locator('div[role="dialog"]');
+    await expect(modal).toBeVisible();
+    await expect(modal.getByRole('heading', { name: /Code Generator/i })).toBeVisible();
+
+    // 4. Assert Download button in modal is visible and enabled
+    const downloadBtn = modal.getByRole('button', { name: /Download/i });
+    await expect(downloadBtn).toBeVisible();
+    await expect(downloadBtn).toBeEnabled();
+
+    // 5. Verify language tabs update state (R, SAS, Python, Stata)
+    const languages = [
+      { name: 'R', extension: '.R' },
+      { name: 'SAS', extension: '.sas' },
+      { name: 'Python', extension: '.py' },
+      { name: 'Stata', extension: '.do' }
+    ];
+
+    for (const lang of languages) {
+      const tab = modal.getByRole('button', { name: lang.name, exact: true });
+      await tab.click();
+      // Wait for code to refresh (represented by the Download button remaining enabled/visible)
+      await expect(downloadBtn).toBeVisible();
+
+      const downloadPromise = page.waitForEvent('download');
+      await downloadBtn.click();
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toContain(lang.extension);
+    }
+
+    // 6. Close modal
+    await modal.getByRole('button', { name: /Close/i }).click();
+    await expect(modal).toBeHidden();
+  });
+});


### PR DESCRIPTION
Add E2E smoke tests for CSV, PDF, and code export UX. The tests verify that the corresponding buttons are visible, enabled, and correctly trigger download events with the expected file extensions. This includes testing the Code Generator modal across multiple languages (R, SAS, Python, Stata).

Fixes #307

---
*PR created automatically by Jules for task [8410527868840475392](https://jules.google.com/task/8410527868840475392) started by @fderuiter*