### PR TITLE
Fix CI YAML syntax errors in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,7 +411,7 @@ jobs:
   merge_reports:
     runs-on: ubuntu-latest
     needs: e2e
-    if: !cancelled() && needs.e2e.result != 'skipped'
+    if: "!cancelled() && needs.e2e.result != 'skipped'"
     permissions:
       contents: read
 
@@ -472,7 +472,7 @@ jobs:
   traceability_matrix:
     runs-on: ubuntu-latest
     needs: [setup, merge_reports, python_script_execution_check, sas_static_validation, stata_static_validation, metadata_validation, cross_env_equivalence, sbom, security_scan, lint_actions]
-    if: !cancelled() && needs.setup.result == 'success'
+    if: "!cancelled() && needs.setup.result == 'success'"
     permissions:
       contents: read
 
@@ -573,7 +573,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python_script_execution_check, sas_static_validation, 
         stata_static_validation, cross_env_equivalence]
-    if: !cancelled()
+    if: "!cancelled()"
     permissions:
       contents: read
 


### PR DESCRIPTION
This PR fixes invalid YAML syntax in the CI workflow file. GitHub Actions expressions starting with an exclamation mark (`!`) are interpreted as YAML tags, which leads to parsing errors if they are not quoted.

I have wrapped the following `if:` conditions in double quotes:
- `!cancelled() && needs.e2e.result != 'skipped'`
- `!cancelled() && needs.setup.result == 'success'`
- `!cancelled()`

These changes ensure the workflow file is valid and can be correctly parsed by GitHub Actions.

Fixes #619

---
*PR created automatically by Jules for task [9222894923930149838](https://jules.google.com/task/9222894923930149838) started by @fderuiter*