### PR TITLE
Prevent dynamic and bundle export modes for Minimization studies

### DIFF
--- a/src/app/domain/schema-management/components/code-generator-modal.component.html
+++ b/src/app/domain/schema-management/components/code-generator-modal.component.html
@@ -36,13 +36,18 @@
                       <app-button variant="segmented" (onClick)="setExportMode('STATIC')" [segmentedActive]="exportMode() === 'STATIC'" segmentedPosition="first" role="radio" [attr.aria-checked]="exportMode() === 'STATIC' ? 'true' : 'false'">
                         Static Manifest
                       </app-button>
-                      <app-button variant="segmented" (onClick)="setExportMode('DYNAMIC')" [segmentedActive]="exportMode() === 'DYNAMIC'" segmentedPosition="middle" role="radio" [attr.aria-checked]="exportMode() === 'DYNAMIC' ? 'true' : 'false'">
+                      <app-button variant="segmented" (onClick)="setExportMode('DYNAMIC')" [segmentedActive]="exportMode() === 'DYNAMIC'" [disabled]="isMinimization()" segmentedPosition="middle" role="radio" [attr.aria-checked]="exportMode() === 'DYNAMIC' ? 'true' : 'false'">
                         Dynamic Generator
                       </app-button>
-                      <app-button variant="segmented" (onClick)="setExportMode('BOTH')" [segmentedActive]="exportMode() === 'BOTH'" segmentedPosition="last" role="radio" [attr.aria-checked]="exportMode() === 'BOTH' ? 'true' : 'false'">
+                      <app-button variant="segmented" (onClick)="setExportMode('BOTH')" [segmentedActive]="exportMode() === 'BOTH'" [disabled]="isMinimization()" segmentedPosition="last" role="radio" [attr.aria-checked]="exportMode() === 'BOTH' ? 'true' : 'false'">
                         Both (ZIP Bundle)
                       </app-button>
                     </nav>
+                    @if (isMinimization()) {
+                      <span class="text-xs text-muted max-w-sm mt-1" role="note">
+                        Dynamic export is not yet available for Pocock-Simon minimization. A static manifest preserves the generated allocation sequence.
+                      </span>
+                    }
                   </div>
 
                   <div class="flex flex-col gap-2">

--- a/src/app/domain/schema-management/components/code-generator-modal.component.spec.ts
+++ b/src/app/domain/schema-management/components/code-generator-modal.component.spec.ts
@@ -7,11 +7,13 @@ import { CodeGenerationError } from '../errors/code-generation-errors';
 import { signal } from '@angular/core';
 import { vi } from 'vitest';
 import { RandomizationConfig } from '../../core/models/randomization.model';
+import { AnnouncementService } from '../../../core/services/announcement.service';
 
 describe('CodeGeneratorModalComponent (domain)', () => {
   let component: CodeGeneratorModalComponent;
   let mockFacade: unknown;
   let mockCodeGeneratorService: unknown;
+  let mockAnnouncementService: { announce: any };
 
   beforeEach(async () => {
     mockFacade = {
@@ -34,10 +36,15 @@ describe('CodeGeneratorModalComponent (domain)', () => {
       generateSas: vi.fn().mockReturnValue('Mock SAS Code')
     };
 
+    mockAnnouncementService = {
+      announce: vi.fn()
+    };
+
     TestBed.configureTestingModule({
       providers: [
         { provide: RandomizationEngineFacade, useValue: mockFacade },
-        { provide: CodeGeneratorService, useValue: mockCodeGeneratorService }
+        { provide: CodeGeneratorService, useValue: mockCodeGeneratorService },
+        { provide: AnnouncementService, useValue: mockAnnouncementService }
       ]
     });
 
@@ -276,6 +283,80 @@ describe('CodeGeneratorModalComponent (domain)', () => {
       await component.setActiveTab('SAS');
       expect(component.errorState()).toBeNull();
       expect(component.currentCode).toBe('Good SAS code');
+    });
+  });
+
+  describe('Pocock-Simon Minimization UX Fallback', () => {
+    let mockMinimizationConfig: RandomizationConfig;
+
+    beforeEach(() => {
+      mockMinimizationConfig = {
+        protocolId: 'MIN-TEST',
+        studyName: 'Minimization Study',
+        phase: 'Phase II',
+        arms: [
+          { id: '1', name: 'Arm A', ratio: 1 },
+          { id: '2', name: 'Arm B', ratio: 1 }
+        ],
+        sites: ['Site1'],
+        strata: [{ id: 'gender', name: 'Gender', levels: ['Male', 'Female'] }],
+        blockSizes: [],
+        stratumCaps: [],
+        seed: 'min_seed',
+        subjectIdMask: '[SiteID]-[001]',
+        randomizationMethod: 'MINIMIZATION',
+        minimizationConfig: { p: 0.8, totalSampleSize: 100 }
+      };
+    });
+
+    it('should open in Static Manifest mode on initialization', async () => {
+      (mockFacade as any).config.set(mockMinimizationConfig);
+      // Create new component to test initialization
+      let testComponent: CodeGeneratorModalComponent;
+      await TestBed.runInInjectionContext(async () => {
+        testComponent = new CodeGeneratorModalComponent();
+        testComponent.exportMode.set('DYNAMIC'); // simulate stale state before init
+        await testComponent.ngOnInit();
+      });
+
+      expect(testComponent!.exportMode()).toBe('STATIC');
+      expect(testComponent!.isMinimization()).toBe(true);
+    });
+
+    it('should automatically set exportMode to STATIC if dynamic or both are selected', async () => {
+      (mockFacade as any).config.set(mockMinimizationConfig);
+      await component.ngOnInit();
+
+      await component.setExportMode('DYNAMIC');
+      expect(component.exportMode()).toBe('STATIC'); // setExportMode guards
+
+      component.exportMode.set('BOTH'); // programmatically bypass guard
+      await (component as any).refreshCode();
+      expect(component.exportMode()).toBe('STATIC'); // refreshCode normalizes
+      expect(mockAnnouncementService.announce).toHaveBeenCalledWith(
+        'Dynamic export is not yet available for Pocock-Simon minimization. Switched to Static Manifest.',
+        'assertive'
+      );
+    });
+
+    it('should normalize exportMode to STATIC on downloadCode', async () => {
+      (mockFacade as any).config.set(mockMinimizationConfig);
+      await component.ngOnInit();
+
+      component.exportMode.set('DYNAMIC'); // programmatic stale state
+
+      const appendSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((n) => n as Node);
+      vi.spyOn(document.body, 'removeChild').mockImplementation((n) => n as Node);
+
+      await component.downloadCode();
+
+      expect(component.exportMode()).toBe('STATIC');
+      vi.restoreAllMocks();
+    });
+
+    it('should verify isMinimization computed signal is true', () => {
+      (mockFacade as any).config.set(mockMinimizationConfig);
+      expect(component.isMinimization()).toBe(true);
     });
   });
 });

--- a/src/app/domain/schema-management/components/code-generator-modal.component.ts
+++ b/src/app/domain/schema-management/components/code-generator-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal, inject, OnInit, ChangeDetectionStrategy, HostListener } from '@angular/core';
+import { Component, signal, inject, OnInit, ChangeDetectionStrategy, HostListener, computed } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { ButtonComponent } from '../../../core/components/ui/button.component';
 import { RandomizationEngineFacade } from '../../randomization-engine/randomization-engine.facade';
@@ -27,6 +27,7 @@ export class CodeGeneratorModalComponent implements OnInit {
 
   activeTab = signal<'R' | 'SAS' | 'Python' | 'STATA'>('R');
   exportMode = signal<'STATIC' | 'DYNAMIC' | 'BOTH'>('STATIC');
+  isMinimization = computed(() => this.state.config()?.randomizationMethod === 'MINIMIZATION');
   copied = signal(false);
   errorState = signal<CodeGenerationError | null>(null);
   generatedCode = signal<string>('');
@@ -38,6 +39,13 @@ export class CodeGeneratorModalComponent implements OnInit {
 
   async ngOnInit() {
     this.activeTab.set(this.state.codeLanguage());
+    if (this.isMinimization() && (this.exportMode() === 'DYNAMIC' || this.exportMode() === 'BOTH')) {
+      this.exportMode.set('STATIC');
+      this.announcementService.announce(
+        'Dynamic export is not yet available for Pocock-Simon minimization. Switched to Static Manifest.',
+        'assertive'
+      );
+    }
     await this.refreshCode();
   }
 
@@ -51,6 +59,9 @@ export class CodeGeneratorModalComponent implements OnInit {
   }
 
   async setExportMode(mode: 'STATIC' | 'DYNAMIC' | 'BOTH') {
+    if (this.isMinimization() && mode !== 'STATIC') {
+      return;
+    }
     this.exportMode.set(mode);
     await this.refreshCode();
   }
@@ -61,6 +72,13 @@ export class CodeGeneratorModalComponent implements OnInit {
     if (!config) {
       this.generatedCode.set('');
       return;
+    }
+    if (config.randomizationMethod === 'MINIMIZATION' && (this.exportMode() === 'DYNAMIC' || this.exportMode() === 'BOTH')) {
+      this.exportMode.set('STATIC');
+      this.announcementService.announce(
+        'Dynamic export is not yet available for Pocock-Simon minimization. Switched to Static Manifest.',
+        'assertive'
+      );
     }
     try {
       let metadata: RandomizationResult['metadata'];
@@ -177,6 +195,10 @@ export class CodeGeneratorModalComponent implements OnInit {
 
     const config = this.state.config();
     if (!config) return;
+
+    if (config.randomizationMethod === 'MINIMIZATION' && (this.exportMode() === 'DYNAMIC' || this.exportMode() === 'BOTH')) {
+      this.exportMode.set('STATIC');
+    }
 
     const tab = this.activeTab();
     const extension = tab === 'R' ? 'R' : tab === 'SAS' ? 'sas' : tab === 'STATA' ? 'do' : 'py';


### PR DESCRIPTION
This PR implements the UX fallback for Pocock-Simon Minimization studies in the Code Generator. It disables the unsupported "Dynamic Generator" and "Both (ZIP Bundle)" segmented buttons, adds a clear inline explanation, and programmatically falls back to "Static Manifest" if any stale state or programmatic calls attempt to access dynamic modes for minimization. Unit tests and visual verification are included.

Fixes #650

---
*PR created automatically by Jules for task [7192558290720053173](https://jules.google.com/task/7192558290720053173) started by @fderuiter*